### PR TITLE
[Fix/#63] like아이콘 20px일때와 36px일때 구분

### DIFF
--- a/public/svg/ic_fill_like_off_36.svg
+++ b/public/svg/ic_fill_like_off_36.svg
@@ -1,0 +1,28 @@
+<svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_1024_5413)">
+<g clip-path="url(#clip1_1024_5413)">
+<g filter="url(#filter0_d_1024_5413)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M18.3759 9.01232C15.646 5.82087 11.0938 4.96238 7.67341 7.88479C4.25308 10.8072 3.77154 15.6933 6.45755 19.1497C8.69079 22.0234 15.4493 28.0843 17.6644 30.046C17.9122 30.2654 18.0362 30.3752 18.1807 30.4183C18.3068 30.4559 18.4449 30.4559 18.571 30.4183C18.7156 30.3752 18.8395 30.2654 19.0873 30.046C21.3024 28.0843 28.0609 22.0234 30.2942 19.1497C32.9802 15.6933 32.5574 10.7765 29.0783 7.88479C25.5992 4.99312 21.1057 5.82087 18.3759 9.01232Z" fill="#C4C4C4" fill-opacity="0.65" shape-rendering="crispEdges"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M18.3759 9.01232C15.646 5.82087 11.0938 4.96238 7.67341 7.88479C4.25308 10.8072 3.77154 15.6933 6.45755 19.1497C8.69079 22.0234 15.4493 28.0843 17.6644 30.046C17.9122 30.2654 18.0362 30.3752 18.1807 30.4183C18.3068 30.4559 18.4449 30.4559 18.571 30.4183C18.7156 30.3752 18.8395 30.2654 19.0873 30.046C21.3024 28.0843 28.0609 22.0234 30.2942 19.1497C32.9802 15.6933 32.5574 10.7765 29.0783 7.88479C25.5992 4.99312 21.1057 5.82087 18.3759 9.01232Z" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" shape-rendering="crispEdges"/>
+</g>
+</g>
+</g>
+<defs>
+<filter id="filter0_d_1024_5413" x="1.68338" y="3.0462" width="33.4037" height="30.4484" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="1.02403"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1024_5413"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1024_5413" result="shape"/>
+</filter>
+<clipPath id="clip0_1024_5413">
+<rect width="32" height="32" fill="white" transform="translate(2 2)"/>
+</clipPath>
+<clipPath id="clip1_1024_5413">
+<rect width="32.769" height="32.769" fill="white" transform="translate(2 2)"/>
+</clipPath>
+</defs>
+</svg>

--- a/public/svg/ic_fill_like_on_36.svg
+++ b/public/svg/ic_fill_like_on_36.svg
@@ -1,0 +1,28 @@
+<svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_1024_5412)">
+<g clip-path="url(#clip1_1024_5412)">
+<g filter="url(#filter0_d_1024_5412)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M18.3759 9.01232C15.646 5.82087 11.0938 4.96238 7.67341 7.88479C4.25308 10.8072 3.77154 15.6933 6.45755 19.1497C8.69079 22.0234 15.4493 28.0843 17.6644 30.046C17.9122 30.2654 18.0362 30.3752 18.1807 30.4183C18.3068 30.4559 18.4449 30.4559 18.571 30.4183C18.7156 30.3752 18.8395 30.2654 19.0873 30.046C21.3024 28.0843 28.0609 22.0234 30.2942 19.1497C32.9802 15.6933 32.5574 10.7765 29.0783 7.88479C25.5992 4.99312 21.1057 5.82087 18.3759 9.01232Z" fill="#F24D4D"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M18.3759 9.01232C15.646 5.82087 11.0938 4.96238 7.67341 7.88479C4.25308 10.8072 3.77154 15.6933 6.45755 19.1497C8.69079 22.0234 15.4493 28.0843 17.6644 30.046C17.9122 30.2654 18.0362 30.3752 18.1807 30.4183C18.3068 30.4559 18.4449 30.4559 18.571 30.4183C18.7156 30.3752 18.8395 30.2654 19.0873 30.046C21.3024 28.0843 28.0609 22.0234 30.2942 19.1497C32.9802 15.6933 32.5574 10.7765 29.0783 7.88479C25.5992 4.99312 21.1057 5.82087 18.3759 9.01232Z" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+</g>
+</g>
+<defs>
+<filter id="filter0_d_1024_5412" x="1.68338" y="3.0462" width="33.4037" height="30.4484" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset/>
+<feGaussianBlur stdDeviation="1.02403"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1024_5412"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1024_5412" result="shape"/>
+</filter>
+<clipPath id="clip0_1024_5412">
+<rect width="32" height="32" fill="white" transform="translate(2 2)"/>
+</clipPath>
+<clipPath id="clip1_1024_5412">
+<rect width="32.769" height="32.769" fill="white" transform="translate(2 2)"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/assets/svgs/IcFillLikeOff36.tsx
+++ b/src/assets/svgs/IcFillLikeOff36.tsx
@@ -1,0 +1,70 @@
+import type { SVGProps } from 'react';
+const SvgIcFillLikeOff36 = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 36 36"
+    {...props}
+  >
+    <g clipPath="url(#ic_fill_like_off_36_svg__a)">
+      <g
+        clipPath="url(#ic_fill_like_off_36_svg__b)"
+        clipRule="evenodd"
+        filter="url(#ic_fill_like_off_36_svg__c)"
+        shapeRendering="crispEdges"
+      >
+        <path
+          fill="#C4C4C4"
+          fillOpacity={0.65}
+          fillRule="evenodd"
+          d="M18.376 9.012c-2.73-3.191-7.282-4.05-10.703-1.127S3.772 15.693 6.458 19.15c2.233 2.873 8.991 8.934 11.206 10.896.248.22.372.33.517.372a.7.7 0 0 0 .39 0c.145-.043.268-.153.516-.372 2.215-1.962 8.974-8.023 11.207-10.896 2.686-3.457 2.263-8.373-1.216-11.265S21.106 5.82 18.376 9.012"
+        />
+        <path
+          stroke="#fff"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M18.376 9.012c-2.73-3.191-7.282-4.05-10.703-1.127S3.772 15.693 6.458 19.15c2.233 2.873 8.991 8.934 11.206 10.896.248.22.372.33.517.372a.7.7 0 0 0 .39 0c.145-.043.268-.153.516-.372 2.215-1.962 8.974-8.023 11.207-10.896 2.686-3.457 2.263-8.373-1.216-11.265S21.106 5.82 18.376 9.012"
+        />
+      </g>
+    </g>
+    <defs>
+      <clipPath id="ic_fill_like_off_36_svg__a">
+        <path fill="#fff" d="M2 2h32v32H2z" />
+      </clipPath>
+      <clipPath id="ic_fill_like_off_36_svg__b">
+        <path fill="#fff" d="M2 2h32.769v32.769H2z" />
+      </clipPath>
+      <filter
+        id="ic_fill_like_off_36_svg__c"
+        width={33.404}
+        height={30.448}
+        x={1.683}
+        y={3.046}
+        colorInterpolationFilters="sRGB"
+        filterUnits="userSpaceOnUse"
+      >
+        <feFlood floodOpacity={0} result="BackgroundImageFix" />
+        <feColorMatrix
+          in="SourceAlpha"
+          result="hardAlpha"
+          values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+        />
+        <feOffset />
+        <feGaussianBlur stdDeviation={1.024} />
+        <feComposite in2="hardAlpha" operator="out" />
+        <feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0" />
+        <feBlend
+          in2="BackgroundImageFix"
+          result="effect1_dropShadow_1024_5413"
+        />
+        <feBlend
+          in="SourceGraphic"
+          in2="effect1_dropShadow_1024_5413"
+          result="shape"
+        />
+      </filter>
+    </defs>
+  </svg>
+);
+export default SvgIcFillLikeOff36;

--- a/src/assets/svgs/IcFillLikeOn36.tsx
+++ b/src/assets/svgs/IcFillLikeOn36.tsx
@@ -1,0 +1,68 @@
+import type { SVGProps } from 'react';
+const SvgIcFillLikeOn36 = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 36 36"
+    {...props}
+  >
+    <g clipPath="url(#ic_fill_like_on_36_svg__a)">
+      <g
+        clipPath="url(#ic_fill_like_on_36_svg__b)"
+        clipRule="evenodd"
+        filter="url(#ic_fill_like_on_36_svg__c)"
+      >
+        <path
+          fill="#F24D4D"
+          fillRule="evenodd"
+          d="M18.376 9.012c-2.73-3.191-7.282-4.05-10.703-1.127S3.772 15.693 6.458 19.15c2.233 2.873 8.991 8.934 11.206 10.896.248.22.372.33.517.372a.7.7 0 0 0 .39 0c.145-.043.268-.153.516-.372 2.215-1.962 8.974-8.023 11.207-10.896 2.686-3.457 2.263-8.373-1.216-11.265S21.106 5.82 18.376 9.012"
+        />
+        <path
+          stroke="#fff"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M18.376 9.012c-2.73-3.191-7.282-4.05-10.703-1.127S3.772 15.693 6.458 19.15c2.233 2.873 8.991 8.934 11.206 10.896.248.22.372.33.517.372a.7.7 0 0 0 .39 0c.145-.043.268-.153.516-.372 2.215-1.962 8.974-8.023 11.207-10.896 2.686-3.457 2.263-8.373-1.216-11.265S21.106 5.82 18.376 9.012"
+        />
+      </g>
+    </g>
+    <defs>
+      <clipPath id="ic_fill_like_on_36_svg__a">
+        <path fill="#fff" d="M2 2h32v32H2z" />
+      </clipPath>
+      <clipPath id="ic_fill_like_on_36_svg__b">
+        <path fill="#fff" d="M2 2h32.769v32.769H2z" />
+      </clipPath>
+      <filter
+        id="ic_fill_like_on_36_svg__c"
+        width={33.404}
+        height={30.448}
+        x={1.683}
+        y={3.046}
+        colorInterpolationFilters="sRGB"
+        filterUnits="userSpaceOnUse"
+      >
+        <feFlood floodOpacity={0} result="BackgroundImageFix" />
+        <feColorMatrix
+          in="SourceAlpha"
+          result="hardAlpha"
+          values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+        />
+        <feOffset />
+        <feGaussianBlur stdDeviation={1.024} />
+        <feComposite in2="hardAlpha" operator="out" />
+        <feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0" />
+        <feBlend
+          in2="BackgroundImageFix"
+          result="effect1_dropShadow_1024_5412"
+        />
+        <feBlend
+          in="SourceGraphic"
+          in2="effect1_dropShadow_1024_5412"
+          result="shape"
+        />
+      </filter>
+    </defs>
+  </svg>
+);
+export default SvgIcFillLikeOn36;

--- a/src/assets/svgs/index.ts
+++ b/src/assets/svgs/index.ts
@@ -1,11 +1,13 @@
+export { default as IcArrowDown20 } from './IcArrowDown20';
+export { default as IcArrowUp20 } from './IcArrowUp20';
+export { default as IcFillLikeOff36 } from './IcFillLikeOff36';
+export { default as IcFillLikeOn36 } from './IcFillLikeOn36';
 export { default as IcGpsmarkerOff } from './IcGpsmarkerOff';
 export { default as IcGpsmarkerOn } from './IcGpsmarkerOn';
 export { default as IcKakao } from './IcKakao';
 export { default as IcLineLikeOff20 } from './IcLineLikeOff20';
 export { default as IcLineLikeOn20 } from './IcLineLikeOn20';
+export { default as IcMy } from './IcMy';
 export { default as IcSavedOff24 } from './IcSavedOff24';
 export { default as IcSavedOn24 } from './IcSavedOn24';
-export { default as IcArrowDown20 } from './IcArrowDown20';
-export { default as IcArrowUp20 } from './IcArrowUp20';
-export { default as IcMy } from './IcMy';
 export { default as ImgLogo } from './ImgLogo';

--- a/src/components/common/IconButton/IconButton.css.ts
+++ b/src/components/common/IconButton/IconButton.css.ts
@@ -19,8 +19,11 @@ export const buttonStyle = recipe({
         width: '2.4rem',
         gap: 0,
       },
-      like: {
+      like20: {
         gap: '0.6rem',
+      },
+      like36: {
+        width: '3.6rem',
       },
     },
     onMap: {

--- a/src/components/common/IconButton/IconButton.tsx
+++ b/src/components/common/IconButton/IconButton.tsx
@@ -1,6 +1,8 @@
 import { ButtonHTMLAttributes } from 'react';
 
 import {
+  IcFillLikeOff36,
+  IcFillLikeOn36,
   IcLineLikeOff20,
   IcLineLikeOn20,
   IcSavedOff24,
@@ -11,7 +13,7 @@ import { buttonStyle, countStyle } from './IconButton.css';
 
 export interface IconButtonProps
   extends ButtonHTMLAttributes<HTMLButtonElement> {
-  buttonType: 'save' | 'like';
+  buttonType: 'save' | 'like20' | 'like36';
   isActive?: boolean;
   count?: number;
   onMap: boolean;
@@ -22,9 +24,13 @@ const buttonIcon = {
     active: <IcSavedOn24 width={24} height={24} />,
     inactive: <IcSavedOff24 width={24} height={24} />,
   },
-  like: {
+  like20: {
     active: <IcLineLikeOn20 width={20} height={20} />,
     inactive: <IcLineLikeOff20 width={20} height={20} />,
+  },
+  like36: {
+    active: <IcFillLikeOn36 width={36} height={36} />,
+    inactive: <IcFillLikeOff36 width={36} height={36} />,
   },
 };
 

--- a/src/pages/home/page/HomePage/HomePage.tsx
+++ b/src/pages/home/page/HomePage/HomePage.tsx
@@ -1,5 +1,14 @@
+import { IconButton } from '@components';
+
 const HomePage = () => {
-  return <div>HomePage</div>;
+  return (
+    <div style={{ backgroundColor: 'black' }}>
+      <IconButton buttonType="like20" isActive={true} onMap={false} />
+      <IconButton buttonType="save" isActive={true} onMap={false} />
+      <IconButton buttonType="like36" isActive={true} onMap={false} />
+      <IconButton buttonType="like36" isActive={false} onMap={false} />
+    </div>
+  );
 };
 
 export default HomePage;

--- a/src/pages/home/page/HomePage/HomePage.tsx
+++ b/src/pages/home/page/HomePage/HomePage.tsx
@@ -1,14 +1,5 @@
-import { IconButton } from '@components';
-
 const HomePage = () => {
-  return (
-    <div style={{ backgroundColor: 'black' }}>
-      <IconButton buttonType="like20" isActive={true} onMap={false} />
-      <IconButton buttonType="save" isActive={true} onMap={false} />
-      <IconButton buttonType="like36" isActive={true} onMap={false} />
-      <IconButton buttonType="like36" isActive={false} onMap={false} />
-    </div>
-  );
+  return <div>HomePage</div>;
 };
 
 export default HomePage;


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

### 📌 관련 이슈번호

- Closes #63 
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

---

### 체크리스트

- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요? <!-- e.g. [Feat/#1] 로그인 기능 추가 -->
- [x] 🏗️ 빌드는 성공했나요? (yarn build)
- [x] 🧹 불필요한 코드는 제거했나요? e.g. console.log
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 
- [x] 🏷️ 라벨은 등록했나요?

---

### ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. like 아이콘이 20px, 36px이 있어서 구분지었습니다
   - store페이지의 Image컴포넌트 위에 올라가는 like 아이콘과, 둘러보기 페이지에서의 바텀모달 내부 이미지에서 사용되빈다.

---

### 📢 To Reviewers

-

---

### 📸 스크린샷 or 실행영상
<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
