### PR TITLE
[Fix/#66] Image컴포넌트에서 클릭 영역 수정

### DIFF
--- a/src/components/common/IconButton/IconButton.tsx
+++ b/src/components/common/IconButton/IconButton.tsx
@@ -16,7 +16,7 @@ export interface IconButtonProps
   buttonType: 'save' | 'like20' | 'like36';
   isActive?: boolean;
   count?: number;
-  onMap: boolean;
+  onMap?: boolean;
 }
 
 const buttonIcon = {
@@ -38,7 +38,7 @@ const IconButton = ({
   buttonType,
   isActive,
   count,
-  onMap,
+  onMap = false,
   onClick,
 }: IconButtonProps) => {
   return (

--- a/src/components/common/Image/Image.css.ts
+++ b/src/components/common/Image/Image.css.ts
@@ -7,6 +7,7 @@ import { recipe } from '@vanilla-extract/recipes';
 export const divStyle = style({
   position: 'relative',
   width: '100%',
+  aspectRatio: '1 / 1',
 });
 
 export const numberLabelStyle = style([

--- a/src/components/common/Image/Image.css.ts
+++ b/src/components/common/Image/Image.css.ts
@@ -1,10 +1,12 @@
-import { style, styleVariants } from '@vanilla-extract/css';
+import { style } from '@vanilla-extract/css';
 
 import { flexGenerator } from '@styles/generator.css';
 import { vars } from '@styles/theme.css';
+import { recipe } from '@vanilla-extract/recipes';
 
 export const divStyle = style({
   position: 'relative',
+  width: '100%',
 });
 
 export const numberLabelStyle = style([
@@ -20,9 +22,17 @@ export const numberLabelStyle = style([
   },
 ]);
 
-export const imageStyle = styleVariants({
-  square: { borderRadius: '0px' },
-  rounded: { borderRadius: '4px' },
+export const imageStyle = recipe({
+  base: {
+    width: '100%',
+    height: '100%',
+  },
+  variants: {
+    variant: {
+      square: { borderRadius: '0px' },
+      rounded: { borderRadius: '4px' },
+    },
+  },
 });
 
 export const iconButtonStyle = style({

--- a/src/components/common/Image/Image.tsx
+++ b/src/components/common/Image/Image.tsx
@@ -15,27 +15,32 @@ export interface ImageProps extends HTMLAttributes<HTMLDivElement> {
   variant?: 'square' | 'rounded';
   numberLabel?: string;
   hasIcon?: boolean;
+  isActive?: boolean;
+  onIconClick?: () => void;
 }
 
 const Image = ({
   src,
-  width,
-  height = width,
   variant = 'square',
   numberLabel = '',
   hasIcon = false,
+  isActive,
+  onIconClick,
+  onClick,
 }: ImageProps) => {
   return (
-    <div className={divStyle} style={{ width, height }}>
+    <div className={divStyle} onClick={onClick}>
       {numberLabel && <div className={numberLabelStyle}>{numberLabel}</div>}
-      <img
-        src={src}
-        className={imageStyle[variant]}
-        style={{ width, height }}
-      />
+      <img src={src} className={imageStyle({ variant })} />
       {hasIcon && (
-        <div className={iconButtonStyle}>
-          <IconButton buttonType="like" onMap={false} isActive />
+        <div
+          className={iconButtonStyle}
+          onClick={(e) => {
+            e.stopPropagation();
+            if (onIconClick) onIconClick();
+          }}
+        >
+          <IconButton buttonType="like36" onMap={false} isActive={isActive} />
         </div>
       )}
     </div>

--- a/src/components/common/Image/Image.tsx
+++ b/src/components/common/Image/Image.tsx
@@ -10,8 +10,6 @@ import IconButton from '../IconButton/IconButton';
 
 export interface ImageProps extends HTMLAttributes<HTMLDivElement> {
   src: string;
-  width: string;
-  height?: string;
   variant?: 'square' | 'rounded';
   numberLabel?: string;
   hasIcon?: boolean;
@@ -26,10 +24,9 @@ const Image = ({
   hasIcon = false,
   isActive,
   onIconClick,
-  onClick,
 }: ImageProps) => {
   return (
-    <div className={divStyle} onClick={onClick}>
+    <div className={divStyle}>
       {numberLabel && <div className={numberLabelStyle}>{numberLabel}</div>}
       <img src={src} className={imageStyle({ variant })} />
       {hasIcon && (


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

### 📌 관련 이슈번호

- Closes #66 
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

---

### 체크리스트

- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요? <!-- e.g. [Feat/#1] 로그인 기능 추가 -->
- [x] 🏗️ 빌드는 성공했나요? (yarn build)
- [x] 🧹 불필요한 코드는 제거했나요? e.g. console.log
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 
- [x] 🏷️ 라벨은 등록했나요?

---

### ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. Image컴포넌트 내부에서 IconButton 컴포넌트를 필요로 할 때, Image컴포넌트 클릭시 해당 케이크 가게 상세 페이지로 이동해야하는 이벤트가 필요하고, IconButton 컴포넌트를 클릭시 좋아요 on/off 기능이 필요합니다.
이에 따라 이벤트가 propagation 되지 않도록 수정하고, 두 handleClick 함수 모두 Image컴포넌트를 호출하는 상위 컴포넌트에서 작성하여 prop으로 전달하도록 수정했습니다.


---

### 📢 To Reviewers

<img width="451" alt="image" src="https://github.com/user-attachments/assets/bedd5edd-80b4-4f2f-912c-0fe63ebee3c8" />

사용 방법은 이처럼 하시면 됩니다.
(designList 배열은 예시로 넣어놨습니다)

---

### 📸 스크린샷 or 실행영상
<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
