### PR TITLE
[Feat/#69] DesignCard 컴포넌트 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import {
   viewRoutes,
 } from '@routes';
 
+import DesignCard from './components/common/DesignCard/DesignCard';
 import queryClient from './queryClient';
 
 import '@styles/global.css';
@@ -29,6 +30,7 @@ const App = () => {
   return (
     <QueryClientProvider client={queryClient}>
       <RouterProvider router={router} />
+      <DesignCard />
       <div style={{ fontSize: '16px' }}>
         <ReactQueryDevtools />
       </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,6 @@ import {
   viewRoutes,
 } from '@routes';
 
-import DesignCard from './components/common/DesignCard/DesignCard';
 import queryClient from './queryClient';
 
 import '@styles/global.css';
@@ -30,7 +29,6 @@ const App = () => {
   return (
     <QueryClientProvider client={queryClient}>
       <RouterProvider router={router} />
-      <DesignCard />
       <div style={{ fontSize: '16px' }}>
         <ReactQueryDevtools />
       </div>

--- a/src/components/common/DesignCard/DesignCard.css.ts
+++ b/src/components/common/DesignCard/DesignCard.css.ts
@@ -12,17 +12,15 @@ export const container = style([
 ]);
 
 export const infoContainer = style([
-  flexGenerator(),
+  flexGenerator('row', 'space-between'),
   {
     width: '100%',
-    justifyContent: 'space-between',
-    alignItems: 'center',
   },
 ]);
 
 export const infoWrapper = style([
-  flexGenerator('column'),
-  { gap: '0.6rem', alignItems: 'flex-start' },
+  flexGenerator('column', 'center', 'flex-start'),
+  { gap: '0.6rem' },
 ]);
 
 export const infoTitleStyle = style(vars.fonts.head08_m_18);

--- a/src/components/common/DesignCard/DesignCard.css.ts
+++ b/src/components/common/DesignCard/DesignCard.css.ts
@@ -1,0 +1,28 @@
+import { style } from '@vanilla-extract/css';
+
+import { flexGenerator } from '@styles/generator.css';
+import { vars } from '@styles/theme.css';
+
+export const container = style([
+  flexGenerator('column'),
+  {
+    width: '100%',
+    gap: '1rem',
+  },
+]);
+
+export const infoContainer = style([
+  flexGenerator(),
+  {
+    width: '100%',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+]);
+
+export const infoWrapper = style([
+  flexGenerator('column'),
+  { gap: '0.6rem', alignItems: 'flex-start' },
+]);
+
+export const infoTitleStyle = style(vars.fonts.head08_m_18);

--- a/src/components/common/DesignCard/DesignCard.tsx
+++ b/src/components/common/DesignCard/DesignCard.tsx
@@ -1,0 +1,19 @@
+import IconButton from '../IconButton/IconButton';
+import Image from '../Image/Image';
+import Label from '../Label/Label';
+
+const DesignCard = () => {
+  return (
+    <div>
+      <Image src="../public/example-img.png" width="100%" />
+      <div>
+        <h1>햄니케이크</h1>
+        <Label text="종로5가역" />
+      </div>
+
+      <IconButton buttonType="like20" onMap={false} />
+    </div>
+  );
+};
+
+export default DesignCard;

--- a/src/components/common/DesignCard/DesignCard.tsx
+++ b/src/components/common/DesignCard/DesignCard.tsx
@@ -18,7 +18,7 @@ const DesignCard = ({ designItem, onClick }: DesignCardProps) => {
   const { imageUrl, storeName, station, likeCount, isLiked } = designItem;
 
   return (
-    <div className={container} onClick={onClick}>
+    <article className={container} onClick={onClick}>
       <Image src={imageUrl} variant="rounded" />
       <div className={infoContainer}>
         <div className={infoWrapper}>
@@ -27,7 +27,7 @@ const DesignCard = ({ designItem, onClick }: DesignCardProps) => {
         </div>
         <IconButton buttonType="like20" count={likeCount} isActive={isLiked} />
       </div>
-    </div>
+    </article>
   );
 };
 

--- a/src/components/common/DesignCard/DesignCard.tsx
+++ b/src/components/common/DesignCard/DesignCard.tsx
@@ -1,22 +1,15 @@
 import { HTMLAttributes } from 'react';
 
+import { IconButton, Image, Label } from '@components';
+
 import {
   container,
   infoContainer,
   infoWrapper,
   infoTitleStyle,
 } from './DesignCard.css';
-import IconButton from '../IconButton/IconButton';
-import Image from '../Image/Image';
-import Label from '../Label/Label';
 
-interface DesignItemType {
-  imageUrl: string;
-  storeName: string;
-  station: string;
-  likeCount: number;
-  isLiked: boolean;
-}
+import { DesignItemType } from '@types';
 interface DesignCardProps extends HTMLAttributes<HTMLDivElement> {
   designItem: DesignItemType;
 }

--- a/src/components/common/DesignCard/DesignCard.tsx
+++ b/src/components/common/DesignCard/DesignCard.tsx
@@ -1,17 +1,39 @@
+import { HTMLAttributes } from 'react';
+
+import {
+  container,
+  infoContainer,
+  infoWrapper,
+  infoTitleStyle,
+} from './DesignCard.css';
 import IconButton from '../IconButton/IconButton';
 import Image from '../Image/Image';
 import Label from '../Label/Label';
 
-const DesignCard = () => {
-  return (
-    <div>
-      <Image src="../public/example-img.png" width="100%" />
-      <div>
-        <h1>햄니케이크</h1>
-        <Label text="종로5가역" />
-      </div>
+interface DesignItemType {
+  imageUrl: string;
+  storeName: string;
+  station: string;
+  likeCount: number;
+  isLiked: boolean;
+}
+interface DesignCardProps extends HTMLAttributes<HTMLDivElement> {
+  designItem: DesignItemType;
+}
 
-      <IconButton buttonType="like20" onMap={false} />
+const DesignCard = ({ designItem, onClick }: DesignCardProps) => {
+  const { imageUrl, storeName, station, likeCount, isLiked } = designItem;
+
+  return (
+    <div className={container} onClick={onClick}>
+      <Image src={imageUrl} variant="rounded" />
+      <div className={infoContainer}>
+        <div className={infoWrapper}>
+          <h1 className={infoTitleStyle}>{storeName}</h1>
+          <Label text={station} />
+        </div>
+        <IconButton buttonType="like20" count={likeCount} isActive={isLiked} />
+      </div>
     </div>
   );
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,2 @@
 export * from './routeType';
+export * from './types';

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,0 +1,7 @@
+export interface DesignItemType {
+    imageUrl: string;
+    storeName: string;
+    station: string;
+    likeCount: number;
+    isLiked: boolean;
+  }


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

### 📌 관련 이슈번호

- Closes #69
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

---

### 체크리스트

- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요? <!-- e.g. [Feat/#1] 로그인 기능 추가 -->
- [x] 🏗️ 빌드는 성공했나요? (yarn build)
- [x] 🧹 불필요한 코드는 제거했나요? e.g. console.log
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 
- [x] 🏷️ 라벨은 등록했나요?

---

### ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1.DesignCard 컴포넌트 만들었습니다.
- `designItem`(필수): designCard에 들어갈 내용을 받습니다.

사용할 땐 다음과 같이 사용합니다.
아래와 같이 디자인 카드에 들어갈 정보가 내려온다고 할 때,
```
const cakes = [
  {
    cakeId: 1,
    storeId: 1,
    storeName: '버터뭉',
    station: '홍대입구역',
    isLiked: false,
    likeCount: 200,
    imageUrl: '../public/example-img.png',
  },
  {
    cakeId: 2,
    storeId: 2,
    storeName: '버터뭉2',
    station: '서강대입구역',
    isLiked: true,
    likeCount: 30,
    imageUrl: '../public/example-img.png',
  },
  {
    cakeId: 3,
    storeId: 1,
    storeName: '버터뭉',
    station: '홍대입구역',
    isLiked: false,
    likeCount: 200,
    imageUrl: '../public/example-img.png',
  },
];
```

DesignCard를 사용하는 곳에서 정보를 넘겨주기만 하면,
imageUrl, storeName, station, likeCount, isLiked와 같은 값들이 자기 자리를 찾아 쏙쏙 들어가게 됩니다.
```
<div>
        {cakes.map((cake) => {
          return (
            <DesignCard designItem={cake}
            />
          );
        })}
 </div>
```


---

### 📢 To Reviewers

-

---

### 📸 스크린샷 or 실행영상
<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
<img width="186" alt="스크린샷 2025-01-14 오후 11 42 43" src="https://github.com/user-attachments/assets/a0fd3c02-20aa-4778-b407-0ff6a6226a30" />

