### PR TITLE
[Feat/#73] LocationSelectButton 컴포넌트 구현 완료

### DIFF
--- a/public/svg/ic_check.svg
+++ b/public/svg/ic_check.svg
@@ -1,0 +1,3 @@
+<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6.4165 14L11.6665 19.8333L22.1665 8.16663" stroke="#1D1D1D" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/svgs/IcCheck.tsx
+++ b/src/assets/svgs/IcCheck.tsx
@@ -1,0 +1,18 @@
+import type { SVGProps } from 'react';
+const SvgIcCheck = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 28 28"
+    {...props}
+  >
+    <path
+      stroke="#1D1D1D"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="m6.417 14 5.25 5.833 10.5-11.666"
+    />
+  </svg>
+);
+export default SvgIcCheck;

--- a/src/assets/svgs/index.ts
+++ b/src/assets/svgs/index.ts
@@ -1,5 +1,6 @@
 export { default as IcArrowDown20 } from './IcArrowDown20';
 export { default as IcArrowUp20 } from './IcArrowUp20';
+export { default as IcCheck } from './IcCheck';
 export { default as IcFillLikeOff36 } from './IcFillLikeOff36';
 export { default as IcFillLikeOn36 } from './IcFillLikeOn36';
 export { default as IcGpsmarkerOff } from './IcGpsmarkerOff';

--- a/src/pages/view/components/LocationSelectButton/LocationSelectButton.css.ts
+++ b/src/pages/view/components/LocationSelectButton/LocationSelectButton.css.ts
@@ -1,0 +1,38 @@
+import { flexGenerator } from '@styles/generator.css';
+import { vars } from '@styles/theme.css';
+import { styleVariants } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+export const buttonStyle = recipe({
+  base: [
+    flexGenerator('row', 'space-between'),
+    {
+      width: '100%',
+      padding: '1.4rem 1rem 1.4rem 1.8rem',
+      backgroundColor: vars.colors.white,
+      borderRadius: 10,
+    },
+  ],
+  variants: {
+    isSelected: {
+      true: {
+        backgroundColor: vars.colors.yellow2,
+      },
+    },
+  },
+});
+
+export const buttonTextStyle = styleVariants({
+  true: [
+    vars.fonts.head08_m_18,
+    {
+      color: vars.colors.gray900,
+    },
+  ],
+  false: [
+    vars.fonts.head09_r_18,
+    {
+      color: vars.colors.gray500,
+    },
+  ],
+});

--- a/src/pages/view/components/LocationSelectButton/LocationSelectButton.tsx
+++ b/src/pages/view/components/LocationSelectButton/LocationSelectButton.tsx
@@ -1,0 +1,28 @@
+import { IcCheck } from '@svgs';
+import { ButtonHTMLAttributes } from 'react';
+import { buttonStyle, buttonTextStyle } from './LocationSelectButton.css';
+
+export interface LocationSelectButtonProps
+  extends ButtonHTMLAttributes<HTMLButtonElement> {
+  location: string;
+  currentLocation: string;
+}
+
+const LocationSelectButton = ({
+  location,
+  currentLocation,
+  onClick,
+}: LocationSelectButtonProps) => {
+  const isSelected = location === currentLocation;
+
+  return (
+    <button className={buttonStyle({ isSelected })} onClick={onClick}>
+      <span className={buttonTextStyle[isSelected ? 'true' : 'false']}>
+        {location}
+      </span>
+      {isSelected && <IcCheck width={28} height={28} />}
+    </button>
+  );
+};
+
+export default LocationSelectButton;

--- a/src/pages/view/components/LocationSelectButton/LocationSelectButton.tsx
+++ b/src/pages/view/components/LocationSelectButton/LocationSelectButton.tsx
@@ -17,9 +17,7 @@ const LocationSelectButton = ({
 
   return (
     <button className={buttonStyle({ isSelected })} onClick={onClick}>
-      <span className={buttonTextStyle[isSelected ? 'true' : 'false']}>
-        {location}
-      </span>
+      <span className={buttonTextStyle[`${isSelected}`]}>{location}</span>
       {isSelected && <IcCheck width={28} height={28} />}
     </button>
   );

--- a/src/pages/view/components/index.ts
+++ b/src/pages/view/components/index.ts
@@ -1,0 +1,3 @@
+import LocationSelectButton from './LocationSelectButton/LocationSelectButton';
+
+export { LocationSelectButton };


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

### 📌 관련 이슈번호

- Closes #73 
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

---

### 체크리스트

- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요? <!-- e.g. [Feat/#1] 로그인 기능 추가 -->
- [x] 🏗️ 빌드는 성공했나요? (yarn build)
- [x] 🧹 불필요한 코드는 제거했나요? e.g. console.log
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 
- [x] 🏷️ 라벨은 등록했나요?

---

### ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 지하철역을 선택하는 모달 페이지에서 각 지하철역 버튼 컴포넌트를 구현했습니다.
   - map에서 돌린 location값과 currentLocation값이 같으면 선택된것으로 인식합니다.


---

### 📢 To Reviewers

-

---

### 📸 스크린샷 or 실행영상
<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->

<img width="368" alt="image" src="https://github.com/user-attachments/assets/965e519f-8f39-453e-af1a-5671c9b75692" />
<img width="381" alt="image" src="https://github.com/user-attachments/assets/adbc1c90-f471-4014-ad7d-b5db41e1c14b" />
