### PR TITLE
[Fix/#79] store tab 컴포넌트 상하 padding 값 수정

### DIFF
--- a/src/components/common/Tab/Tab.css.ts
+++ b/src/components/common/Tab/Tab.css.ts
@@ -25,7 +25,7 @@ export const tabButton = recipe({
       store: [
         vars.fonts.body04_m_16,
         {
-          padding: '1rem 0',
+          padding: '1.6rem 0',
         },
       ],
     },


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

### 📌 관련 이슈번호

- Closes #79 
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

---

### 체크리스트

- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요? <!-- e.g. [Feat/#1] 로그인 기능 추가 -->
- [x] 🏗️ 빌드는 성공했나요? (yarn build)
- [x] 🧹 불필요한 코드는 제거했나요? e.g. console.log
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 
- [x] 🏷️ 라벨은 등록했나요?

---

### ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. store tab 컴포넌트 상하 padding 값을 수정했습니다!!
- 1rem이었던 컴포넌트 상하 padding 값을 디자인 파트 요청에 따라 1.6rem으로 수정했습니다~!!


---

### 📢 To Reviewers

-

---

### 📸 스크린샷 or 실행영상
<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
