### PR TITLE
[Fix/#88] IconButton 컴포넌트 수정

### DIFF
--- a/src/components/common/DesignCard/DesignCard.tsx
+++ b/src/components/common/DesignCard/DesignCard.tsx
@@ -14,18 +14,28 @@ interface DesignCardProps extends HTMLAttributes<HTMLDivElement> {
   designItem: DesignItemType;
 }
 
-const DesignCard = ({ designItem, onClick }: DesignCardProps) => {
-  const { imageUrl, storeName, station, likeCount, isLiked } = designItem;
+const DesignCard = ({ designItem }: DesignCardProps) => {
+  const { storeId, cakeId, imageUrl, storeName, station, likeCount, isLiked } =
+    designItem;
+
+  const handleCardClick = () => {
+    console.log('디자인카드 클릭', storeId);
+  };
 
   return (
-    <article className={container} onClick={onClick}>
+    <article className={container} onClick={handleCardClick}>
       <Image src={imageUrl} variant="rounded" />
       <div className={infoContainer}>
         <div className={infoWrapper}>
           <h1 className={infoTitleStyle}>{storeName}</h1>
           <Label text={station} />
         </div>
-        <IconButton buttonType="like20" count={likeCount} isActive={isLiked} />
+        <IconButton
+          buttonType="like20"
+          count={likeCount}
+          isActive={isLiked}
+          itemId={cakeId}
+        />
       </div>
     </article>
   );

--- a/src/components/common/IconButton/IconButton.tsx
+++ b/src/components/common/IconButton/IconButton.tsx
@@ -16,6 +16,7 @@ export interface IconButtonProps
   buttonType: 'save' | 'like20' | 'like36';
   isActive?: boolean;
   count?: number;
+  itemId?: number; // storeId | cakeId를 받아서 api 요청에 사용합니다
   onMap?: boolean;
 }
 
@@ -38,11 +39,17 @@ const IconButton = ({
   buttonType,
   isActive,
   count,
+  itemId,
   onMap = false,
-  onClick,
 }: IconButtonProps) => {
+  const handleButtonClick = () => {
+    console.log('iconClick');
+  };
   return (
-    <button className={buttonStyle({ buttonType, onMap })} onClick={onClick}>
+    <button
+      className={buttonStyle({ buttonType, onMap })}
+      onClick={handleButtonClick}
+    >
       {isActive
         ? buttonIcon[buttonType]?.active
         : buttonIcon[buttonType]?.inactive}

--- a/src/components/common/IconButton/IconButton.tsx
+++ b/src/components/common/IconButton/IconButton.tsx
@@ -1,4 +1,4 @@
-import { ButtonHTMLAttributes } from 'react';
+import React, { ButtonHTMLAttributes } from 'react';
 
 import {
   IcFillLikeOff36,
@@ -42,8 +42,9 @@ const IconButton = ({
   itemId,
   onMap = false,
 }: IconButtonProps) => {
-  const handleButtonClick = () => {
-    console.log('iconClick');
+  const handleButtonClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    console.log('iconClick', itemId);
   };
   return (
     <button

--- a/src/components/common/Image/Image.tsx
+++ b/src/components/common/Image/Image.tsx
@@ -14,6 +14,7 @@ export interface ImageProps extends HTMLAttributes<HTMLDivElement> {
   numberLabel?: string;
   hasIcon?: boolean;
   isActive?: boolean;
+  itemId?: number;
   onIconClick?: () => void;
 }
 
@@ -23,6 +24,7 @@ const Image = ({
   numberLabel = '',
   hasIcon = false,
   isActive,
+  itemId, // storeId | cakeId를 받아서 IconButton으로 넘겨줍니다
   onIconClick,
 }: ImageProps) => {
   return (
@@ -37,7 +39,12 @@ const Image = ({
             if (onIconClick) onIconClick();
           }}
         >
-          <IconButton buttonType="like36" onMap={false} isActive={isActive} />
+          <IconButton
+            buttonType="like36"
+            onMap={false}
+            isActive={isActive}
+            itemId={itemId}
+          />
         </div>
       )}
     </div>

--- a/src/components/common/StoreCard/StoreCard.tsx
+++ b/src/components/common/StoreCard/StoreCard.tsx
@@ -22,7 +22,7 @@ interface StoreCardProps extends HTMLAttributes<HTMLButtonElement> {
   storeItem: StoreType;
 }
 
-const StoreCard = ({ storeItem, onClick }: StoreCardProps) => {
+const StoreCard = ({ storeItem }: StoreCardProps) => {
   const {
     storeId,
     storeName,
@@ -38,8 +38,12 @@ const StoreCard = ({ storeItem, onClick }: StoreCardProps) => {
       ? `${storeName.slice(0, MAX_STORE_NAME_LENGTH)}..`
       : storeName;
 
+  const handleCardClick = () => {
+    console.log('스토어카드 클릭', storeId);
+  };
+
   return (
-    <article className={storeCardContainer} onClick={onClick}>
+    <article className={storeCardContainer} onClick={handleCardClick}>
       <div className={storeCardWrapper}>
         <div className={storeCardInformation}>
           <div className={storeNameLabel}>
@@ -52,6 +56,7 @@ const StoreCard = ({ storeItem, onClick }: StoreCardProps) => {
           buttonType={'save'}
           isActive={isLiked}
           count={storeLikesCount}
+          itemId={storeId}
         />
       </div>
       <div className={storeCardImageList}>

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -8,6 +8,7 @@ import SocialLoginButton from './SocialLoginButton/SocialLoginButton';
 import StoreCard from './StoreCard/StoreCard';
 import Tab from './Tab/Tab';
 import TextButton from './TextButton/TextButton';
+import DesignCard from './DesignCard/DesignCard';
 
 export {
   Label,
@@ -20,4 +21,5 @@ export {
   IconButton,
   StoreCard,
   Image,
+  DesignCard,
 };

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -14,9 +14,11 @@ export interface StoreType {
 }
 
 export interface DesignItemType {
-    imageUrl: string;
-    storeName: string;
-    station: string;
-    likeCount: number;
-    isLiked: boolean;
+  storeId: number;
+  cakeId: number;
+  imageUrl: string;
+  storeName: string;
+  station: string;
+  likeCount: number;
+  isLiked: boolean;
 }


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

### 📌 관련 이슈번호

- Closes #88 
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

---

### 체크리스트

- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요? <!-- e.g. [Feat/#1] 로그인 기능 추가 -->
- [x] 🏗️ 빌드는 성공했나요? (yarn build)
- [x] 🧹 불필요한 코드는 제거했나요? e.g. console.log
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 
- [x] 🏷️ 라벨은 등록했나요?

---

### ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. IconButton 컴포넌트 내부로 click이벤트 handle함수 이동
- 기존의 IconButton은 onClick을 prop으로 받고 내부에서는 따로 handle함수를 정의하지 않아서 항상 호출하는 상위 컴포넌트에서 handle함수를 만들어서 넘겨줬어야 했습니다.
- IconButton의 onClick기능은 찜 on/off, 좋아요 on/off 를 다루는 api 요청밖에 없기 때문에 이를 IconButton 컴포넌트 내부로 이동시켰습니다.
2. DesignCard, StoreCard도 그에 따라 클릭 이벤트 위치 수정


---

### 📢 To Reviewers

-

---

### 📸 스크린샷 or 실행영상
<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
