### PR TITLE
[Feat/#143] 스토어 좌표 리스트 조회 API 연결

### DIFF
--- a/src/apis/view/useFetchStoreCoordinateList.ts
+++ b/src/apis/view/useFetchStoreCoordinateList.ts
@@ -1,7 +1,24 @@
-import { queryKey } from '@constants';
 import { useSuspenseQuery } from '@tanstack/react-query';
 
-const fetchStoreCoordinateList = async (station: string): Promise<> => {};
+import { instance } from '@apis/instance';
+
+import { END_POINT, queryKey } from '@constants';
+
+import { ApiResponseType, StationCoordinateType } from '@types';
+
+const fetchStoreCoordinateList = async (
+  station: string
+): Promise<StationCoordinateType> => {
+  try {
+    const response = await instance.get<ApiResponseType<StationCoordinateType>>(
+      END_POINT.FETCH_STORE_COORDINATE_LIST(station)
+    );
+    return response.data.data;
+  } catch (error) {
+    console.log(error);
+    throw error;
+  }
+};
 
 export const useFetchStoreCoordinateList = (station: string) => {
   return useSuspenseQuery({

--- a/src/apis/view/useFetchStoreCoordinateList.ts
+++ b/src/apis/view/useFetchStoreCoordinateList.ts
@@ -1,7 +1,11 @@
-import { useSuspenseQuery } from "@tanstack/react-query"
+import { queryKey } from '@constants';
+import { useSuspenseQuery } from '@tanstack/react-query';
 
-export const useFetchStoreCoordinateList = () => {
-    return useSuspenseQuery({
-        
-    })
-}
+const fetchStoreCoordinateList = async (station: string): Promise<> => {};
+
+export const useFetchStoreCoordinateList = (station: string) => {
+  return useSuspenseQuery({
+    queryKey: [queryKey.STORE_COORDINATE_LIST],
+    queryFn: () => fetchStoreCoordinateList(station),
+  });
+};

--- a/src/apis/view/useFetchStoreCoordinateList.ts
+++ b/src/apis/view/useFetchStoreCoordinateList.ts
@@ -1,0 +1,7 @@
+import { useSuspenseQuery } from "@tanstack/react-query"
+
+export const useFetchStoreCoordinateList = () => {
+    return useSuspenseQuery({
+        
+    })
+}

--- a/src/apis/view/useFetchStoreCoordinateList.ts
+++ b/src/apis/view/useFetchStoreCoordinateList.ts
@@ -4,16 +4,20 @@ import { instance } from '@apis/instance';
 
 import { END_POINT, queryKey } from '@constants';
 
-import { ApiResponseType, StationCoordinateType } from '@types';
+import {
+  ApiResponseType,
+  StoreCoordinate,
+  StoreCoordinateListResponse,
+} from '@types';
 
 const fetchStoreCoordinateList = async (
   station: string
-): Promise<StationCoordinateType> => {
+): Promise<StoreCoordinate[]> => {
   try {
-    const response = await instance.get<ApiResponseType<StationCoordinateType>>(
-      END_POINT.FETCH_STORE_COORDINATE_LIST(station)
-    );
-    return response.data.data;
+    const response = await instance.get<
+      ApiResponseType<StoreCoordinateListResponse>
+    >(END_POINT.FETCH_STORE_COORDINATE_LIST(station));
+    return response.data.data.stores;
   } catch (error) {
     console.log(error);
     throw error;
@@ -22,7 +26,7 @@ const fetchStoreCoordinateList = async (
 
 export const useFetchStoreCoordinateList = (station: string) => {
   return useSuspenseQuery({
-    queryKey: [queryKey.STORE_COORDINATE_LIST],
+    queryKey: [queryKey.STORE_COORDINATE_LIST, station],
     queryFn: () => fetchStoreCoordinateList(station),
   });
 };

--- a/src/constants/apis/api.ts
+++ b/src/constants/apis/api.ts
@@ -2,4 +2,6 @@ export const BASE_URL = import.meta.env.VITE_APP_BASE_URL;
 
 export const END_POINT = {
   FETCH_STORE_RANK: '/api/v1/store/rank',
+  FETCH_STORE_COORDINATE_LIST: (station: string) =>
+    `/api/v1/store/coordinate-list?station=${station}`,
 } as const;

--- a/src/constants/apis/queryKey.ts
+++ b/src/constants/apis/queryKey.ts
@@ -1,3 +1,4 @@
 export const queryKey = {
   STORE_RANK: 'storeRank',
+  
 } as const;

--- a/src/constants/apis/queryKey.ts
+++ b/src/constants/apis/queryKey.ts
@@ -1,4 +1,4 @@
 export const queryKey = {
   STORE_RANK: 'storeRank',
-  
+  STORE_COORDINATE_LIST: 'storeCoordinateList',
 } as const;

--- a/src/constants/stations.tsx
+++ b/src/constants/stations.tsx
@@ -65,72 +65,72 @@ const ALLSTATIONLOCATIONS = [
   {
     storeId: 1,
     latitude: 37.556621,
-    longitutde: 126.923877,
+    longitude: 126.923877,
   },
   {
     storeId: 2,
     latitude: 37.55223,
-    longitutde: 126.92244,
+    longitude: 126.92244,
   },
   {
     storeId: 3,
     latitude: 37.561056,
-    longitutde: 126.922655,
+    longitude: 126.922655,
   },
   {
     storeId: 4,
     latitude: 37.555134,
-    longitutde: 126.936778,
+    longitude: 126.936778,
   },
   {
     storeId: 5,
     latitude: 37.558982,
-    longitutde: 126.925856,
+    longitude: 126.925856,
   },
   {
     storeId: 6,
     latitude: 37.554738,
-    longitutde: 126.921476,
+    longitude: 126.921476,
   },
   {
     storeId: 7,
     latitude: 37.559743,
-    longitutde: 126.930125,
+    longitude: 126.930125,
   },
   {
     storeId: 8,
     latitude: 37.556328,
-    longitutde: 126.928901,
+    longitude: 126.928901,
   },
   {
     storeId: 9,
     latitude: 37.557112,
-    longitutde: 126.922348,
+    longitude: 126.922348,
   },
   {
     storeId: 10,
     latitude: 37.554297,
-    longitutde: 126.924713,
+    longitude: 126.924713,
   },
   {
     storeId: 11,
     latitude: 37.556742,
-    longitutde: 126.927189,
+    longitude: 126.927189,
   },
   {
     storeId: 12,
     latitude: 37.558414,
-    longitutde: 126.923305,
+    longitude: 126.923305,
   },
   {
     storeId: 13,
     latitude: 37.553839,
-    longitutde: 126.920731,
+    longitude: 126.920731,
   },
   {
     storeId: 14,
     latitude: 37.55912,
-    longitutde: 126.92645,
+    longitude: 126.92645,
   },
 ];
 
@@ -138,42 +138,42 @@ const HONGDAELOCATIONS = [
   {
     storeId: 1,
     latitude: 37.556621,
-    longitutde: 126.923877,
+    longitude: 126.923877,
   },
   {
     storeId: 2,
     latitude: 37.55223,
-    longitutde: 126.92244,
+    longitude: 126.92244,
   },
   {
     storeId: 3,
     latitude: 37.561056,
-    longitutde: 126.922655,
+    longitude: 126.922655,
   },
   {
     storeId: 4,
     latitude: 37.555134,
-    longitutde: 126.936778,
+    longitude: 126.936778,
   },
   {
     storeId: 5,
     latitude: 37.558982,
-    longitutde: 126.925856,
+    longitude: 126.925856,
   },
   {
     storeId: 6,
     latitude: 37.554738,
-    longitutde: 126.921476,
+    longitude: 126.921476,
   },
   {
     storeId: 7,
     latitude: 37.559743,
-    longitutde: 126.930125,
+    longitude: 126.930125,
   },
   {
     storeId: 8,
     latitude: 37.556328,
-    longitutde: 126.928901,
+    longitude: 126.928901,
   },
 ];
 
@@ -181,47 +181,47 @@ const SAVEDLOCATIONS = [
   {
     storeId: 6,
     latitude: 37.554738,
-    longitutde: 126.921476,
+    longitude: 126.921476,
   },
   {
     storeId: 7,
     latitude: 37.559743,
-    longitutde: 126.930125,
+    longitude: 126.930125,
   },
   {
     storeId: 8,
     latitude: 37.556328,
-    longitutde: 126.928901,
+    longitude: 126.928901,
   },
   {
     storeId: 9,
     latitude: 37.557112,
-    longitutde: 126.922348,
+    longitude: 126.922348,
   },
   {
     storeId: 10,
     latitude: 37.554297,
-    longitutde: 126.924713,
+    longitude: 126.924713,
   },
   {
     storeId: 11,
     latitude: 37.556742,
-    longitutde: 126.927189,
+    longitude: 126.927189,
   },
   {
     storeId: 12,
     latitude: 37.558414,
-    longitutde: 126.923305,
+    longitude: 126.923305,
   },
   {
     storeId: 13,
     latitude: 37.553839,
-    longitutde: 126.920731,
+    longitude: 126.920731,
   },
   {
     storeId: 14,
     latitude: 37.55912,
-    longitutde: 126.92645,
+    longitude: 126.92645,
   },
 ];
 

--- a/src/pages/view/components/KakaoMap/KakaoMap.tsx
+++ b/src/pages/view/components/KakaoMap/KakaoMap.tsx
@@ -57,7 +57,7 @@ const KakaoMap = ({ currentLocation }: KakaoMapProps) => {
             return (
               <MapMarker
                 key={location.storeId}
-                position={{ lat: location.latitude, lng: location.longitutde }}
+                position={{ lat: location.latitude, lng: location.longitude }}
                 image={{
                   src,
                   size,

--- a/src/pages/view/hooks/useKakaoMap.tsx
+++ b/src/pages/view/hooks/useKakaoMap.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
 
+import { useFetchStoreCoordinateList } from '@apis/view/useFetchStoreCoordinateList';
+
 import {
   ALLSTATIONLOCATIONS,
   HONGDAELOCATIONS,
@@ -8,7 +10,7 @@ import {
 
 import { useDebounce } from './useDebounce';
 
-import { BottomSheetState, StationCoordinateType, StationType } from '@types';
+import { BottomSheetState, StationType, StoreCoordinate } from '@types';
 
 const DEFAULT_CENTER = { lat: 37.556621, lng: 126.923877 };
 
@@ -16,9 +18,13 @@ export const useKakaoMap = (
   currentLocation: StationType,
   handleAnimateChange: (animate: BottomSheetState) => void
 ) => {
+  const { data: storeCoordinateList } = useFetchStoreCoordinateList(
+    currentLocation.stationEnName
+  );
+
   const [selectedStoreId, setSelectedStoreId] = useState<number>(0);
   const [storeMarkerList, setStoreMarkerList] = useState<
-    (StationCoordinateType & { clicked: boolean })[]
+    (StoreCoordinate & { clicked: boolean })[]
   >([]);
 
   // 현재 사용자의 위치
@@ -129,6 +135,17 @@ export const useKakaoMap = (
       ALLSTATIONLOCATIONS.map((location) => ({ ...location, clicked: false }))
     );
   }, []);
+
+  useEffect(() => {
+    if (storeCoordinateList) {
+      setStoreMarkerList(
+        storeCoordinateList.map((store) => ({
+          ...store,
+          clicked: false,
+        }))
+      );
+    }
+  }, [storeCoordinateList]);
 
   return {
     selectedStoreId,

--- a/src/pages/view/hooks/useKakaoMap.tsx
+++ b/src/pages/view/hooks/useKakaoMap.tsx
@@ -8,7 +8,7 @@ import {
 
 import { useDebounce } from './useDebounce';
 
-import { BottomSheetState, CoordinateType, StationType } from '@types';
+import { BottomSheetState, StationCoordinateType, StationType } from '@types';
 
 const DEFAULT_CENTER = { lat: 37.556621, lng: 126.923877 };
 
@@ -18,7 +18,7 @@ export const useKakaoMap = (
 ) => {
   const [selectedStoreId, setSelectedStoreId] = useState<number>(0);
   const [storeMarkerList, setStoreMarkerList] = useState<
-    (CoordinateType & { clicked: boolean })[]
+    (StationCoordinateType & { clicked: boolean })[]
   >([]);
 
   // 현재 사용자의 위치

--- a/src/types/apis/view/index.ts
+++ b/src/types/apis/view/index.ts
@@ -1,0 +1,1 @@
+// export interface 

--- a/src/types/apis/view/index.ts
+++ b/src/types/apis/view/index.ts
@@ -1,5 +1,10 @@
-export interface StationCoordinateType {
-  storeId: number;
-  latitude: number;
-  longitutde: number;
-}
+export interface StoreCoordinate {
+    storeId: number;
+    latitude: number;
+    longitude: number;
+  }
+  
+  export interface StoreCoordinateListResponse {
+    stores: StoreCoordinate[];
+  }
+  

--- a/src/types/apis/view/index.ts
+++ b/src/types/apis/view/index.ts
@@ -1,1 +1,5 @@
-// export interface 
+export interface StationCoordinateType {
+  storeId: number;
+  latitude: number;
+  longitutde: number;
+}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -61,10 +61,4 @@ export interface StationType {
   longitude: number;
 }
 
-export interface CoordinateType {
-  storeId: number;
-  latitude: number;
-  longitutde: number;
-}
-
 export type BottomSheetState = 'closed' | 'default' | 'opened';


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

### 📌 관련 이슈번호

- Closes #143 
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

---

### 체크리스트

- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요? <!-- e.g. [Feat/#1] 로그인 기능 추가 -->
- [x] 🏗️ 빌드는 성공했나요? (yarn build)
- [x] 🧹 불필요한 코드는 제거했나요? e.g. console.log
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 
- [x] 🏷️ 라벨은 등록했나요?

---

### ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. view 페이지에서 지하철역 별 지도 위에 띄울 마커의 정보를 가져오는 api를 연결했습니다.
   - 선택된 지하철역의 영어 이름 (ex. ALL, HONGDAE) 을 request parameter로 보내주면 됩니다.


---

### 📢 To Reviewers

-

---

### 📸 스크린샷 or 실행영상
<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
