### PR TITLE
[Feat/#147] 전체 지하철역 조회 API 연결

### DIFF
--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -5,7 +5,7 @@ import { BASE_URL } from '@constants';
 export const instance = axios.create({
   baseURL: BASE_URL,
 
-  withCredentials: false,
+  withCredentials: true,
 });
 
 export function get<T>(...args: Parameters<typeof instance.get>) {

--- a/src/apis/view/index.ts
+++ b/src/apis/view/index.ts
@@ -1,0 +1,4 @@
+import { useFetchStations } from './useFetchStations';
+import { useFetchStoreCoordinateList } from './useFetchStoreCoordinateList';
+
+export { useFetchStations, useFetchStoreCoordinateList };

--- a/src/apis/view/useFetchStations.ts
+++ b/src/apis/view/useFetchStations.ts
@@ -1,0 +1,30 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { instance } from '@apis/instance';
+
+import { END_POINT, queryKey } from '@constants';
+
+import { ApiResponseType, StationType } from '@types';
+
+const fetchStations = async (): Promise<StationType[] | null> => {
+  try {
+    const response = await instance.get<ApiResponseType<StationType[]>>(
+      END_POINT.FETCH_STORE_STATIONS
+    );
+    return response.data.data;
+  } catch (error) {
+    console.log(error);
+    return null;
+  }
+};
+
+export const useFetchStations = () => {
+  return useQuery({
+    queryKey: [queryKey.STORE_STATIONS],
+    queryFn: () => fetchStations(),
+    staleTime: 1000 * 60 * 60 * 24, // 24시간
+    gcTime: 1000 * 60 * 60 * 24 * 7, // 7일
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+  });
+};

--- a/src/constants/apis/api.ts
+++ b/src/constants/apis/api.ts
@@ -4,5 +4,6 @@ export const END_POINT = {
   FETCH_STORE_RANK: '/api/v1/store/rank',
   FETCH_STORE_COORDINATE_LIST: (station: string) =>
     `/api/v1/store/coordinate-list?station=${station}`,
+  FETCH_STORE_STATIONS: '/api/v1/store/station',
   KAKAO_LOGIN: '/api/v1/user/login',
 } as const;

--- a/src/constants/apis/queryKey.ts
+++ b/src/constants/apis/queryKey.ts
@@ -1,5 +1,6 @@
 export const queryKey = {
   STORE_RANK: 'storeRank',
   STORE_COORDINATE_LIST: 'storeCoordinateList',
+  STORE_STATIONS: 'storeStations',
   KAKAO_LOGIN: 'kakaoLogin',
 } as const;

--- a/src/pages/view/hooks/useKakaoMap.tsx
+++ b/src/pages/view/hooks/useKakaoMap.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-import { useFetchStoreCoordinateList } from '@apis/view/useFetchStoreCoordinateList';
+import { useFetchStoreCoordinateList } from '@apis/view';
 
 import {
   ALLSTATIONLOCATIONS,

--- a/src/pages/view/page/ViewPage/ViewPage.tsx
+++ b/src/pages/view/page/ViewPage/ViewPage.tsx
@@ -19,8 +19,6 @@ const ViewPage = () => {
     latitude: 0.0,
     longitude: 0.0,
   });
-  console.log(stations);
-  console.log('currentLocation', currentLocation);
   const stationKrNames = (stations || []).map(
     (station) => station.stationKrName
   );

--- a/src/pages/view/page/ViewPage/ViewPage.tsx
+++ b/src/pages/view/page/ViewPage/ViewPage.tsx
@@ -1,6 +1,6 @@
 import { startTransition, useState } from 'react';
 
-import { useFetchStations } from '@apis/view/useFetchStations';
+import { useFetchStations } from '@apis/view';
 
 import { Modal } from '@components';
 import { useModal } from '@hooks';

--- a/src/pages/view/page/ViewPage/ViewPage.tsx
+++ b/src/pages/view/page/ViewPage/ViewPage.tsx
@@ -1,18 +1,17 @@
-import { useEffect, useState } from 'react';
+import { startTransition, useState } from 'react';
+
+import { useFetchStations } from '@apis/view/useFetchStations';
 
 import { Modal } from '@components';
 import { useModal } from '@hooks';
 import { LocationButton, SelectStationModal } from '@pages/view/components';
 import { KakaoMap } from '@pages/view/components';
-import { STATIONS } from 'src/constants/stations';
 
 import { locationButtonWrapper } from './ViewPage.css';
 
-import { StationType } from '@types';
-
 const ViewPage = () => {
   const { isModalOpen, openModal, closeModal } = useModal();
-  const [stations] = useState<StationType[]>(STATIONS);
+  const { data: stations } = useFetchStations();
 
   const [currentLocation, setCurrentLocation] = useState({
     stationEnName: 'ALL',
@@ -20,24 +19,25 @@ const ViewPage = () => {
     latitude: 0.0,
     longitude: 0.0,
   });
-
-  const stationKrNames = stations.map((station) => station.stationKrName);
+  console.log(stations);
+  console.log('currentLocation', currentLocation);
+  const stationKrNames = (stations || []).map(
+    (station) => station.stationKrName
+  );
 
   const handleCurrentLocationChange = (stationName: string) => {
-    const selectedStation = stations.find(
+    const selectedStation = (stations || []).find(
       (station) => station.stationKrName === stationName
     );
 
     if (selectedStation) {
-      setCurrentLocation(selectedStation);
+      startTransition(() => {
+        setCurrentLocation(selectedStation);
+      });
     } else {
       console.error(`Station "${stationName}" not found`);
     }
   };
-
-  useEffect(() => {
-    // 전체 지하철역 조회 api get
-  }, []);
 
   return (
     <div>

--- a/src/types/apis/view/index.ts
+++ b/src/types/apis/view/index.ts
@@ -1,10 +1,16 @@
 export interface StoreCoordinate {
-    storeId: number;
-    latitude: number;
-    longitude: number;
-  }
-  
-  export interface StoreCoordinateListResponse {
-    stores: StoreCoordinate[];
-  }
-  
+  storeId: number;
+  latitude: number;
+  longitude: number;
+}
+
+export interface StoreCoordinateListResponse {
+  stores: StoreCoordinate[];
+}
+
+export interface StationType {
+  stationEnName: string;
+  stationKrName: string;
+  latitude: number;
+  longitude: number;
+}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -54,11 +54,4 @@ export type SubCategoryType =
 export type ItemType = 'store' | 'design' | 'likedStore' | 'likedDesign';
 export type OptionType = 'latest' | 'popularity';
 
-export interface StationType {
-  stationEnName: string;
-  stationKrName: string;
-  latitude: number;
-  longitude: number;
-}
-
 export type BottomSheetState = 'closed' | 'default' | 'opened';


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

### 📌 관련 이슈번호

- Closes #147 
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

---

### 체크리스트

- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요? <!-- e.g. [Feat/#1] 로그인 기능 추가 -->
- [x] 🏗️ 빌드는 성공했나요? (yarn build)
- [x] 🧹 불필요한 코드는 제거했나요? e.g. console.log
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 
- [x] 🏷️ 라벨은 등록했나요?

---

### ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 전체 지하철역 조회 API 연결했습니다.
   - 전체 지하철역을 조회하는 get 요청은 ViewPage에 처음 로드시 한번만 필요하고, 웬만하면 지하철역 리스트가 추가될 일은 없을것 같아서 useQuery 사용 및 staleTime, gcTime을 다른 api에 비해 매우 길게 설정해놨습니다.
   - 이를 ViewPage 컴포넌트로 가져와서 렌더링 하는 과정에서 아직 정확하게 이해는 못했지만 handleCurrentLocationChange에 의해 currentLocation값을 selectedStation 값으로 업데이트 하는 과정과, KakaoMap 컴포넌트에서 스토어의 좌표를 가져와서 마커를 찍기 위한 api요청에 사용되는 Suspense가 충돌을 한다고 합니다.
   - SetCurrentLocation에 의해 상태가 업데이트 되고, 즉시 컴포넌트가 리렌더링 되는데, 이때 KakaoMap은 currentLocation이 변경되기 때문에 렌더링이 일어납니다. 이때 Suspense에 의해 비동기 작업이 발생하므로, React는 '동기적 입력'이 Suspense에 의해 '중단되었다' 라고 간주하여 충돌이 발생한다고 합니다.
   - 이를 해결하기 위해 setCurrentLocation 과정을 startTransition으로 감싸주면서 해당 상태 업데이트가 저우선 순위임을 알려줍니다.
   이를 통해 Suspense가 발생해도 동기적 입력 흐름을 방해하지 않고 에러가 발생하지 않게 됩니다.

---

### 📢 To Reviewers

-

---

### 📸 스크린샷 or 실행영상
<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
