### PR TITLE
[Feat/#151] 사용자 정보(이름, 이메일) 조회 API 연결

### DIFF
--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -5,7 +5,7 @@ import { BASE_URL } from '@constants';
 export const instance = axios.create({
   baseURL: BASE_URL,
 
-  withCredentials: false,
+  withCredentials: true,
 });
 
 export function get<T>(...args: Parameters<typeof instance.get>) {

--- a/src/apis/myPage/useFetchUser.ts
+++ b/src/apis/myPage/useFetchUser.ts
@@ -1,0 +1,26 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import { instance } from '@apis/instance';
+
+import { END_POINT, queryKey } from '@constants';
+
+import { ApiResponseType, UserResponse } from '@types';
+
+const fetchUser = async (): Promise<UserResponse> => {
+  try {
+    const response = await instance.get<ApiResponseType<UserResponse>>(
+      END_POINT.FETCH_USER
+    );
+    return response.data.data;
+  } catch (error) {
+    console.log(error);
+    throw error;
+  }
+};
+
+export const useFetchUser = () => {
+  return useSuspenseQuery({
+    queryKey: [queryKey.USER],
+    queryFn: fetchUser,
+  });
+};

--- a/src/constants/apis/api.ts
+++ b/src/constants/apis/api.ts
@@ -5,4 +5,5 @@ export const END_POINT = {
   FETCH_STORE_COORDINATE_LIST: (station: string) =>
     `/api/v1/store/coordinate-list?station=${station}`,
   KAKAO_LOGIN: '/api/v1/user/login',
+  FETCH_USER: '/api/v1/user',
 } as const;

--- a/src/constants/apis/queryKey.ts
+++ b/src/constants/apis/queryKey.ts
@@ -2,4 +2,5 @@ export const queryKey = {
   STORE_RANK: 'storeRank',
   STORE_COORDINATE_LIST: 'storeCoordinateList',
   KAKAO_LOGIN: 'kakaoLogin',
+  USER: 'user',
 } as const;

--- a/src/pages/home/page/HomePage/HomePage.tsx
+++ b/src/pages/home/page/HomePage/HomePage.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-
 import { useFetchCakeRank } from '@apis/home';
 
 import { DesignCard } from '@components';
@@ -7,6 +5,7 @@ import { CATEGORY, MainKeyVisual } from '@constants';
 import { useEasyNavigate } from '@hooks';
 import { StoreRankingButton } from '@pages/home/components';
 import CategoryCard from '@pages/home/components/CategoryCard/CategoryCard';
+import { isLoggedIn } from '@utils';
 
 import { IcHomeArrow } from '@svgs';
 
@@ -62,12 +61,13 @@ const storeRankingData = [
   },
 ];
 
-const user = { userName: '박채연' };
-
 const HomePage = () => {
-  const [isLogin] = useState(true);
+  const isLogin = isLoggedIn();
   const { goViewPage } = useEasyNavigate();
   const { data: cakeRankData } = useFetchCakeRank();
+  const user = isLogin
+    ? JSON.parse(localStorage.getItem('user') || '{}')
+    : null;
 
   return (
     <div className={homePageLayout}>

--- a/src/pages/myPage/page/Mypage/MyPage.tsx
+++ b/src/pages/myPage/page/Mypage/MyPage.tsx
@@ -1,7 +1,10 @@
+import { useFetchUser } from '@apis/myPage/useFetchUser';
+
 import { AuthModal, Modal, TextButton } from '@components';
 import { WHIPEE_CONTACT_FORM } from '@constants';
 import { useEasyNavigate, useModal } from '@hooks';
 import { LetsGoButton, ProfileCard } from '@pages/myPage/components';
+import { isLoggedIn } from '@utils';
 
 import {
   letsGoButtonWrapper,
@@ -9,14 +12,8 @@ import {
   profileCardStyle,
 } from './MyPage.css';
 
-const user = {
-  userId: 1,
-  userName: '쥬먐이',
-  userEmail: 'jiyoo0315@naver.com',
-};
-
 const MyPage = () => {
-  const isLogin = true; //추후 삭제 후 localStorage.getItem로 수정할 예정
+  const isLogin = isLoggedIn();
 
   const { isModalOpen, openModal, closeModal } = useModal();
 
@@ -26,13 +23,15 @@ const MyPage = () => {
     window.open(WHIPEE_CONTACT_FORM, '_blank');
   };
 
+  const { data: userData } = useFetchUser();
+
   return (
     <>
       <section className={profileCardStyle[isLogin ? 'login' : 'logout']}>
         <ProfileCard
           isLogin={isLogin}
-          userName={user.userName}
-          userEmail={user.userEmail}
+          userName={userData.userName}
+          userEmail={userData.userEmail}
         />
       </section>
 

--- a/src/types/apis/myPage/index.ts
+++ b/src/types/apis/myPage/index.ts
@@ -1,0 +1,4 @@
+export interface UserResponse {
+  userName: string;
+  userEmail: string;
+}


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

### 📌 관련 이슈번호

- Closes #151 
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

---

### 체크리스트

- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요? <!-- e.g. [Feat/#1] 로그인 기능 추가 -->
- [x] 🏗️ 빌드는 성공했나요? (yarn build)
- [x] 🧹 불필요한 코드는 제거했나요? e.g. console.log
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 
- [x] 🏷️ 라벨은 등록했나요?

---

### ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 사용자 정보(이름, 이메일) 조회 API 연결 성공했습니다.
- 로그인 시, 마이페이지에서 프로필 카드에 카카오톡에 등록된 이름과 이메일이 보이고,
- 로그인이 되어 있지 않을 경우, 마이페이지에서 '로그인 하러 가기' 라는 버튼이 보입니다.
