### PR TITLE
[Feat/#152] 지도 뷰 선택 스토어 모달 구현

### DIFF
--- a/src/components/common/Modal/Modal.css.ts
+++ b/src/components/common/Modal/Modal.css.ts
@@ -1,18 +1,16 @@
 import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
-import { flexGenerator } from '@styles/generator.css';
+import { fixedGenerator, flexGenerator } from '@styles/generator.css';
 import { vars } from '@styles/theme.css';
 
-export const backdropStyle = style({
-  position: 'fixed',
-  left: '0',
-  top: '0',
-  width: '100%',
-  height: '100%',
-  background: vars.colors.dimmed,
-  zIndex: '3',
-});
+export const backdropStyle = style([
+  fixedGenerator({ top: 0, center: true }, 3),
+  {
+    height: '100%',
+    background: vars.colors.dimmed,
+  },
+]);
 
 export const modalStyle = recipe({
   base: [
@@ -27,11 +25,13 @@ export const modalStyle = recipe({
         transform: 'translate(-50%, -50%)',
         borderRadius: '10px',
       },
-      bottom: {
-        bottom: '0',
-        width: '100%',
-        borderRadius: '10px 10px 0px 0px',
-      },
+      bottom: [
+        fixedGenerator({ bottom: 0, center: true }, 4),
+        {
+          borderRadius: '10px 10px 0px 0px',
+          boxShadow: '0px 0px 20px 0px rgba(0, 0, 0, 0.10)',
+        },
+      ],
     },
   },
 });

--- a/src/pages/store/components/ImageModal/ImageModal.css.ts
+++ b/src/pages/store/components/ImageModal/ImageModal.css.ts
@@ -7,9 +7,7 @@ export const modalContainer = style([
   flexGenerator('column', 'flex-start', 'flex-start'),
   {
     position: 'relative',
-    width: '100dvw',
-    maxWidth: 'var(--max-width)',
-    minWidth: 'var(--min-width)',
+    width: '100%',
     height: '100dvh',
     backgroundColor: vars.colors.black,
   },

--- a/src/pages/view/components/KakaoMap/KakaoMap.tsx
+++ b/src/pages/view/components/KakaoMap/KakaoMap.tsx
@@ -19,6 +19,7 @@ import MapBottomSheet from '../MapBottomSheet/MapBottomSheet';
 import MapButton from '../MapButton/MapButton';
 
 import { StationType } from '@types';
+import SelectedStoreModal from '../SelectedStoreModal/SelectedStoreModal';
 
 interface KakaoMapProps {
   currentLocation: StationType;
@@ -97,7 +98,9 @@ const KakaoMap = ({ currentLocation }: KakaoMapProps) => {
           handleAnimateChange={handleAnimateChange}
         />
       ) : (
-        <Modal variant="bottom">1</Modal>
+        <Modal variant="bottom">
+          <SelectedStoreModal storeId={1} />
+        </Modal>
       )}
     </>
   );

--- a/src/pages/view/components/SelectedStoreModal/SelectedStoreModal.css.ts
+++ b/src/pages/view/components/SelectedStoreModal/SelectedStoreModal.css.ts
@@ -1,0 +1,63 @@
+import { style } from '@vanilla-extract/css';
+
+import { flexGenerator } from '@styles/generator.css';
+import { vars } from '@styles/theme.css';
+
+export const modalContainer = style([
+  flexGenerator('row', 'center', 'flex-end'),
+  {
+    gap: '1.6rem',
+    padding: '2rem',
+  },
+]);
+
+export const imageSection = style({
+  width: '16rem',
+  height: '16rem',
+  flexShrink: 0,
+});
+
+export const infoSection = style([
+  flexGenerator('column'),
+  {
+    gap: '1.2rem',
+    width: '100%',
+  },
+]);
+
+export const textWrapper = style([
+  flexGenerator('column'),
+  {
+    gap: '0.8rem',
+    width: '100%',
+  },
+]);
+
+export const storeNameWrapper = style([
+  flexGenerator('row', 'space-between'),
+  vars.fonts.head05_sb_20,
+  {
+    width: '100%',
+    color: vars.colors.black,
+  },
+]);
+
+export const addressWrapper = style([
+  flexGenerator('column', 'center', 'flex-start'),
+  {
+    gap: '0.6rem',
+    width: '100%',
+  },
+]);
+
+export const addressStyle = style([
+  vars.fonts.body07_r_14,
+  {
+    color: vars.colors.gray600,
+    display: '-webkit-box',
+    overflow: 'hidden',
+    WebkitBoxOrient: 'vertical',
+    WebkitLineClamp: 2,
+    wordBreak: 'break-all',
+  },
+]);

--- a/src/pages/view/components/SelectedStoreModal/SelectedStoreModal.css.ts
+++ b/src/pages/view/components/SelectedStoreModal/SelectedStoreModal.css.ts
@@ -8,6 +8,7 @@ export const modalContainer = style([
   {
     gap: '1.6rem',
     padding: '2rem',
+    width: '100%',
   },
 ]);
 

--- a/src/pages/view/components/SelectedStoreModal/SelectedStoreModal.tsx
+++ b/src/pages/view/components/SelectedStoreModal/SelectedStoreModal.tsx
@@ -36,13 +36,14 @@ const SelectedStoreModal = ({ storeId }: SelectedStoreModalProps) => {
         <div className={textWrapper}>
           <div className={storeNameWrapper}>
             <h1>{storeData.storeName}</h1>
-            <IconButton buttonType={'save24'} />
+            <IconButton
+              buttonType={'save24'}
+              isActive={storeData.isLiked}
+              itemId={storeId}
+            />
           </div>
           <div className={addressWrapper}>
-            <p className={addressStyle}>
-              서울 중구 동호로 385-2 아이디어회관
-              301호호호sdkjhfkdksnkjnds호호호호
-            </p>
+            <p className={addressStyle}>{storeData.address}</p>
             <Label text={storeData.station} />
           </div>
         </div>

--- a/src/pages/view/components/SelectedStoreModal/SelectedStoreModal.tsx
+++ b/src/pages/view/components/SelectedStoreModal/SelectedStoreModal.tsx
@@ -1,0 +1,58 @@
+import { IconButton, Image, Label, TextButton } from '@components';
+import { useEasyNavigate } from '@hooks';
+
+import {
+  modalContainer,
+  imageSection,
+  infoSection,
+  textWrapper,
+  storeNameWrapper,
+  addressWrapper,
+  addressStyle,
+} from './SelectedStoreModal.css';
+
+const storeData = {
+  storeName: '버터뭉',
+  address: '서울 중구 동호로 285-2 아이디어회관 301호',
+  station: '홍대입구역',
+  isLiked: true,
+  imageUrl: '/example-img.png',
+  storeLikesCount: 13000,
+};
+
+interface SelectedStoreModalProps {
+  storeId: number;
+}
+const SelectedStoreModal = ({ storeId }: SelectedStoreModalProps) => {
+  const { goStorePage } = useEasyNavigate();
+
+  return (
+    <div className={modalContainer}>
+      <section className={imageSection}>
+        <Image src={storeData.imageUrl} variant="rounded" />
+      </section>
+
+      <section className={infoSection}>
+        <div className={textWrapper}>
+          <div className={storeNameWrapper}>
+            <h1>{storeData.storeName}</h1>
+            <IconButton buttonType={'save24'} />
+          </div>
+          <div className={addressWrapper}>
+            <p className={addressStyle}>
+              서울 중구 동호로 385-2 아이디어회관
+              301호호호sdkjhfkdksnkjnds호호호호
+            </p>
+            <Label text={storeData.station} />
+          </div>
+        </div>
+
+        <TextButton size="small" onClick={() => goStorePage(storeId)}>
+          상세보기
+        </TextButton>
+      </section>
+    </div>
+  );
+};
+
+export default SelectedStoreModal;


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

### 📌 관련 이슈번호

- Closes #152
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

---

### 체크리스트

- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요? <!-- e.g. [Feat/#1] 로그인 기능 추가 -->
- [x] 🏗️ 빌드는 성공했나요? (yarn build)
- [x] 🧹 불필요한 코드는 제거했나요? e.g. console.log
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 
- [x] 🏷️ 라벨은 등록했나요?

---

### ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 지도 뷰에서 마커 클릭 시 뜨는 스토어 모달을 구현했습니다.
2. Modal.css.ts 오버레이 & 바텀 옵션만 fixedGenerator 사용하는 걸로 수정했습니다.

---

### 📢 To Reviewers

-

---

### 📸 스크린샷 or 실행영상
<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
<img width="385" alt="image" src="https://github.com/user-attachments/assets/910cd762-5278-4fdf-8e1d-67ff349c464e" />

