### PR TITLE
[Fix/#171] 둘러보기 페이지 API 오류 해결

### DIFF
--- a/src/apis/designList/useFetchDesignDetail.ts
+++ b/src/apis/designList/useFetchDesignDetail.ts
@@ -41,7 +41,7 @@ export const useFetchDesignDetail = (
   themeName: string
 ) => {
   return useQuery({
-    queryKey: [queryKey.DESIGN_DETAIL],
+    queryKey: [queryKey.DESIGN_DETAIL, cakeId],
     queryFn: () => fetchDesignDetail(cakeId, dayCategory, themeName),
   });
 };

--- a/src/apis/designList/useFetchDesignList.ts
+++ b/src/apis/designList/useFetchDesignList.ts
@@ -40,6 +40,7 @@ export const useFetchDesignList = (
   return useQuery({
     queryKey: [queryKey.DESIGN_LIST, option, dayCategory, themeName],
     queryFn: () => fetchDesignList(option, dayCategory, themeName),
-    staleTime: 0,
+    // staleTime: 0,
+    // gcTime: 0,
   });
 };

--- a/src/apis/designList/useFetchDesignList.ts
+++ b/src/apis/designList/useFetchDesignList.ts
@@ -19,7 +19,7 @@ const fetchDesignList = async (
   } catch (error) {
     const errorResponse = error as ErrorResponse;
     console.log(errorResponse.response.data.code);
-    if (errorResponse.response.data.code === 40420) {
+    if (errorResponse.response.data.code === 40410) {
       return {
         nextCakeIdCursor: 0,
         nextCakeLikesCursor: 0,
@@ -27,8 +27,9 @@ const fetchDesignList = async (
         cakeCount: 0,
         cakes: [],
       };
+    } else {
+      throw error;
     }
-    throw error;
   }
 };
 
@@ -40,7 +41,5 @@ export const useFetchDesignList = (
   return useQuery({
     queryKey: [queryKey.DESIGN_LIST, option, dayCategory, themeName],
     queryFn: () => fetchDesignList(option, dayCategory, themeName),
-    // staleTime: 0,
-    // gcTime: 0,
   });
 };

--- a/src/apis/store/useFetchStoreInfo.ts
+++ b/src/apis/store/useFetchStoreInfo.ts
@@ -20,7 +20,7 @@ const fetchStoreInfo = async (storeId: number): Promise<StoreInfoResponse> => {
 
 export const useFetchStoreInfo = (storeId: number) => {
   return useSuspenseQuery({
-    queryKey: [queryKey.STORE_INFO],
+    queryKey: [queryKey.STORE_INFO, storeId],
     queryFn: () => fetchStoreInfo(storeId),
   });
 };

--- a/src/components/common/CardList/CardList.tsx
+++ b/src/components/common/CardList/CardList.tsx
@@ -1,5 +1,3 @@
-import { useEffect } from 'react';
-
 import {
   cardListContainer,
   cardListNullTextStyle,
@@ -27,7 +25,7 @@ import {
 interface CardListProps {
   item: ItemType;
   itemData?: StoreCardListType | DesignCardListType;
-  option: OptionType
+  option: OptionType;
   handleOptionSelect: (option: OptionType) => void;
   hasModal?: boolean;
   selectedCategories?: {
@@ -55,11 +53,6 @@ const CardList = ({
   ): data is DesignCardListType => {
     return 'cakes' in data && 'cakeCount' in data;
   };
-
-  // 카테고리 변경될 때마다 filtering Button 최신순으로 변경
-  useEffect(() => {
-    handleOptionSelect('latest');
-  }, [selectedCategories]);
 
   // itemData가 StoreCardListType인 경우 stores에 접근 가능
   const cardListData = itemData
@@ -115,7 +108,10 @@ const CardList = ({
               )}
             </div>
 
-            <FilteringButton option={option} onOptionSelect={handleOptionSelect} />
+            <FilteringButton
+              option={option}
+              onOptionSelect={handleOptionSelect}
+            />
           </div>
 
           {item === 'store' || item === 'likedStore' ? (

--- a/src/components/common/CardList/CardList.tsx
+++ b/src/components/common/CardList/CardList.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import {
   cardListContainer,
   cardListNullTextStyle,
@@ -25,6 +27,7 @@ import {
 interface CardListProps {
   item: ItemType;
   itemData?: StoreCardListType | DesignCardListType;
+  option: OptionType
   handleOptionSelect: (option: OptionType) => void;
   hasModal?: boolean;
   selectedCategories?: {
@@ -36,6 +39,7 @@ interface CardListProps {
 const CardList = ({
   item,
   itemData,
+  option,
   handleOptionSelect,
   hasModal,
   selectedCategories,
@@ -51,6 +55,11 @@ const CardList = ({
   ): data is DesignCardListType => {
     return 'cakes' in data && 'cakeCount' in data;
   };
+
+  // 카테고리 변경될 때마다 filtering Button 최신순으로 변경
+  useEffect(() => {
+    handleOptionSelect('latest');
+  }, [selectedCategories]);
 
   // itemData가 StoreCardListType인 경우 stores에 접근 가능
   const cardListData = itemData
@@ -106,7 +115,7 @@ const CardList = ({
               )}
             </div>
 
-            <FilteringButton onOptionSelect={handleOptionSelect} />
+            <FilteringButton option={option} onOptionSelect={handleOptionSelect} />
           </div>
 
           {item === 'store' || item === 'likedStore' ? (

--- a/src/components/common/DesignCard/DesignCard.tsx
+++ b/src/components/common/DesignCard/DesignCard.tsx
@@ -71,7 +71,7 @@ const DesignCard = ({
 
       {isModalOpen && (
         <Modal variant="bottom" hasBackdrop backdropClick={closeModal}>
-          <DesignSearchModal cakeId={cakeId} storeId={storeId} selectedCategories={selectedCategories} />
+          <DesignSearchModal cakeId={cakeId} selectedCategories={selectedCategories} />
         </Modal>
       )}
     </>

--- a/src/components/common/FilteringButton/FilteringButton.tsx
+++ b/src/components/common/FilteringButton/FilteringButton.tsx
@@ -14,6 +14,7 @@ import {
 import { OptionType } from '@types';
 
 interface FilteringButtonProps {
+  option: OptionType
   onOptionSelect: (option: OptionType) => void;
 }
 
@@ -22,9 +23,9 @@ const OPTION = {
   popularity: '인기순',
 };
 
-const FilteringButton = ({ onOptionSelect }: FilteringButtonProps) => {
+const FilteringButton = ({ option, onOptionSelect }: FilteringButtonProps) => {
   const [isOpen, setIsOpen] = useState(false);
-  const [selectedOption, setSelectedOption] = useState<OptionType>('latest');
+  const [selectedOption, setSelectedOption] = useState<OptionType>(option);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   const options: OptionType[] = ['latest', 'popularity'];
@@ -66,7 +67,7 @@ const FilteringButton = ({ onOptionSelect }: FilteringButtonProps) => {
       onClick={toggleDropdown}
       ref={dropdownRef}
     >
-      <button className={buttonTextStyle}>{OPTION[selectedOption]}</button>
+      <button className={buttonTextStyle}>{OPTION[option]}</button>
 
       {isOpen ? (
         <IcArrowUp20 width={24} height={24} />

--- a/src/constants/apis/api.ts
+++ b/src/constants/apis/api.ts
@@ -30,10 +30,6 @@ export const END_POINT = {
   FETCH_STORE_LINK: (storeId: number) => `/api/v1/store/kakaoLink/${storeId}`,
   FETCH_USER: '/api/v1/user',
   FETCH_CAKE_RANK: '/api/v1/cake/rank',
-  // POST_CAKE_LIKES: (cakeId: number) => `/api/v1/cake/likes/${cakeId}`,
-  // POST_STORE_LIKES: (storeId: number) => `/api/v1/store/likes/${storeId}`,
-  // DELETE_CAKE_LIKES: (cakeId: number) => `/api/v1/cake/likes/${cakeId}`,
-  // DELETE_STORE_LIKES: (storeId: number) => `/api/v1/store/likes/${storeId}`
   POST_LIKE: (type: 'cake' | 'store', id: number) =>
     `/api/v1/${type}/likes/${id}`,
   DELETE_LIKE: (type: 'cake' | 'store', id: number) =>

--- a/src/constants/apis/queryKey.ts
+++ b/src/constants/apis/queryKey.ts
@@ -10,7 +10,6 @@ export const queryKey = {
   STORE_DETAIL_SIZE: 'storeDetailSize',
   STORE_DETAIL_INFO: 'storeDetailInfo',
   STORE_LINK: 'storeLink',
-  STORE_COORDINATE_LIST: 'storeCoordinateList',
   SELECT_STORE_COORDINATE: 'selectStoreCoordinate',
   LIKES_STORE_COORDINATE_LIST: 'likesStoreCoordinateList',
   STORE_STATIONS: 'storeStations',

--- a/src/hooks/useFilteredCardList.ts
+++ b/src/hooks/useFilteredCardList.ts
@@ -1,4 +1,4 @@
-import { startTransition, useState } from 'react';
+import { useState } from 'react';
 
 import { OptionType } from '@types';
 
@@ -6,9 +6,8 @@ const useFilteredCardList = () => {
   const [option, setOption] = useState<OptionType>('latest');
 
   const handleOptionSelect = (newOption: OptionType) => {
-    startTransition(() => {
-      setOption(newOption);
-    });
+    setOption(newOption);
+    console.log(option);
   };
 
   return {

--- a/src/hooks/useFilteredCardList.ts
+++ b/src/hooks/useFilteredCardList.ts
@@ -7,7 +7,6 @@ const useFilteredCardList = () => {
 
   const handleOptionSelect = (newOption: OptionType) => {
     setOption(newOption);
-    console.log(option);
   };
 
   return {

--- a/src/pages/designList/components/Carousel/Carousel.css.ts
+++ b/src/pages/designList/components/Carousel/Carousel.css.ts
@@ -21,7 +21,7 @@ export const imageStyle = style({
 
 export const moreButtonStyle = style([
   flexGenerator('column'),
-  { gap: '0.8rem' },
+  { gap: '0.8rem', cursor: 'pointer' },
 ]);
 
 export const moreTextStyle = style([

--- a/src/pages/designList/components/DesignSearchModal/DesignSearchModal.tsx
+++ b/src/pages/designList/components/DesignSearchModal/DesignSearchModal.tsx
@@ -16,7 +16,6 @@ import Carousel from '../Carousel/Carousel';
 import { CategoryType, SubCategoryType } from '@types';
 
 interface DesignSearchModalProps {
-  storeId: number;
   cakeId: number;
   selectedCategories?: {
     category: CategoryType;
@@ -25,11 +24,11 @@ interface DesignSearchModalProps {
 }
 
 const DesignSearchModal = ({
-  storeId,
   cakeId,
   selectedCategories,
 }: DesignSearchModalProps) => {
-  const { data, isLoading } = useFetchDesignDetail(
+  // 디자인 상세보기 조회 api
+  const { data } = useFetchDesignDetail(
     cakeId,
     selectedCategories?.category ?? 'BIRTH',
     selectedCategories?.subCategory ?? 'ALL'
@@ -37,17 +36,11 @@ const DesignSearchModal = ({
 
   const { goStorePage } = useEasyNavigate();
 
-  if (isLoading) {
-    return <div>로딩중...</div>;
-  }
-
   if (!data) {
     return <div>데이터 없음...</div>;
   }
 
-  console.log(cakeId);
-
-  const { storeName, station, cake } = data;
+  const { storeName, station, cake, storeId } = data;
 
   return (
     <div className={searchModalContainer}>

--- a/src/pages/designList/page/DesignListPage/DesignListPage.tsx
+++ b/src/pages/designList/page/DesignListPage/DesignListPage.tsx
@@ -93,6 +93,7 @@ const DesignListPage = () => {
           <CardList
             item="design"
             itemData={DesignListData}
+            option={option}
             handleOptionSelect={handleOptionSelect}
             hasModal
             selectedCategories={selectedCategories}

--- a/src/pages/designList/page/DesignListPage/DesignListPage.tsx
+++ b/src/pages/designList/page/DesignListPage/DesignListPage.tsx
@@ -47,6 +47,7 @@ const DesignListPage = () => {
         category: category,
         subCategory: 'ALL',
       });
+      handleOptionSelect('latest');
     });
   };
 
@@ -56,6 +57,7 @@ const DesignListPage = () => {
         ...prevState,
         subCategory: category,
       }));
+      handleOptionSelect('latest');
     });
   };
 

--- a/src/pages/home/components/CategoryCard/CategoryCard.tsx
+++ b/src/pages/home/components/CategoryCard/CategoryCard.tsx
@@ -28,8 +28,10 @@ const CategoryCard = ({ category }: CategoryCardProps) => {
   return (
     <button className={buttonWrapper} onClick={handleClickButton}>
       <div className={hashtagTextWrapper}>
-        {hashtagText.map((tag) => (
-          <h2 className={hashtagTextStyle}>{tag}</h2>
+        {hashtagText.map((tag, index) => (
+          <h2 className={hashtagTextStyle} key={index}>
+            {tag}
+          </h2>
         ))}
       </div>
       <h1 className={categoryTextStyle}>{categoryText}</h1>

--- a/src/pages/myPage/page/MyList/LikeListPage.tsx
+++ b/src/pages/myPage/page/MyList/LikeListPage.tsx
@@ -42,12 +42,15 @@ const LikeListPage = () => {
           <CardList
             item="likedStore"
             itemData={LikedStoreListData}
+            option={option}
             handleOptionSelect={handleOptionSelect}
           />
-        ) : ( // 여기 일단 store로 둠 ... 나중에 design 연결하는 사람이 바꿔라 ㅋㅋ
+        ) : (
+          // 여기 일단 store로 둠 ... 나중에 design 연결하는 사람이 바꿔라 ㅋㅋ
           <CardList
             item="likedStore"
             itemData={LikedStoreListData}
+            option={option}
             handleOptionSelect={handleOptionSelect}
           />
         )}


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

### 📌 관련 이슈번호

- Closes #171
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

---

### 체크리스트

- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요? <!-- e.g. [Feat/#1] 로그인 기능 추가 -->
- [x] 🏗️ 빌드는 성공했나요? (yarn build)
- [x] 🧹 불필요한 코드는 제거했나요? e.g. console.log
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 
- [x] 🏷️ 라벨은 등록했나요?

---

### ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 디자인 둘러보기 조회 API
   - option에 따라 데이터 로딩이 잘 안되는 문제 해결: useFilteredCardList 훅에서 핸들 함수 뿐 아니라, option도 받아와서 CardList -> FilteringButton까지 전달해주는 걸로 수정해서 옵션이 화면에 . 잘 반영되도록 수정
   
   - 옵션을 '인기순'으로 설정한 후, 카테고리 변경 시 -> 그대로 '인기순'으로 뜨는 문제 해결: 카테고리 변경될 때마다 option이 최신순으로 되도록 useEffect 사용
   
   - 데이터가 없어서 에러 뜨는 경우 해결: 40402 -> 40401 에러로 변경됨에 따라 수정
   
2. 디자인 상세보기 조회 API
   - 캐러셀 더보기 버튼 클릭 후 스토어 페이지 넘어갈 때, 처음 클릭한 스토어 페이지로 계속 나오는 부분 해결: 스토어 페이지 정보를 불러오는 api 쿼리키에 storeId를 추가하여, storeId가 변경되면 데이터를 새롭게 불러오도록 수정


---

### 📢 To Reviewers

-

---

### 📸 스크린샷 or 실행영상
<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
