### PR TITLE
[Feat/#181] Axios interceptor 404 에러 처리 및 스토어 상세보기 관련 API 반영

### DIFF
--- a/src/apis/designList/useFetchDesignList.ts
+++ b/src/apis/designList/useFetchDesignList.ts
@@ -31,15 +31,12 @@ const fetchDesignList = async (
     return response.data.data;
   } catch (error) {
     const errorResponse = error as ErrorResponse;
-    if (errorResponse.response.status === 404) {
+    if (errorResponse.response.status === 404)
       return {
-        nextCakeIdCursor: 0,
-        nextCakeLikesCursor: 0,
-        isLastData: false,
         cakeCount: 0,
+        isLastData: true,
         cakes: [],
       };
-    }
     throw error;
   }
 };

--- a/src/apis/instance.ts
+++ b/src/apis/instance.ts
@@ -8,6 +8,19 @@ export const instance = axios.create({
   withCredentials: true,
 });
 
+instance.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    const errorCodes = [40410, 40420, 40422, 40423, 40424];
+
+    if (errorCodes.includes(error.response?.data?.code)) {
+      return Promise.resolve({ data: null });
+    }
+
+    return Promise.reject(error);
+  }
+);
+
 export function get<T>(...args: Parameters<typeof instance.get>) {
   return instance.get<T>(...args);
 }

--- a/src/apis/myPage/useFetchLikedCakeList.ts
+++ b/src/apis/myPage/useFetchLikedCakeList.ts
@@ -27,14 +27,12 @@ const fetchLikesCardList = async (
     return response.data.data;
   } catch (error) {
     const errorResponse = error as ErrorResponse;
-    if (errorResponse.response.status === 404) {
+    if (errorResponse.response.status === 404)
       return {
-        nextCakeIdCursor: -1,
-        cakeCount: -1,
-        isLastData: false,
+        cakeCount: 0,
+        isLastData: true,
         cakes: [],
       };
-    }
     throw error;
   }
 };
@@ -50,8 +48,6 @@ export const useFetchLikedCakeList = (
         cakeLikesCursor: number;
         cakeIdCursor: number;
       };
-
-      console.log(param);
       return fetchLikesCardList(
         option,
         param.cakeLikesCursor,

--- a/src/apis/myPage/useFetchLikedStoreList.ts
+++ b/src/apis/myPage/useFetchLikedStoreList.ts
@@ -27,14 +27,12 @@ const fetchLikedStoreList = async (
     return response.data.data;
   } catch (error) {
     const errorResponse = error as ErrorResponse;
-    if (errorResponse.response.status === 404) {
+    if (errorResponse.response.status === 404)
       return {
-        nextStoreIdCursor: -1,
-        nextLikesCursor: undefined,
         storeCount: 0,
-        stores: [], // 빈 배열 반환
+        isLastData: true,
+        stores: [],
       };
-    }
     throw error;
   }
 };

--- a/src/apis/store/useFetchSelectStoreCoordinate.ts
+++ b/src/apis/store/useFetchSelectStoreCoordinate.ts
@@ -7,20 +7,16 @@ import { END_POINT, queryKey } from '@constants';
 import { ApiResponseType, StoreCoordinate } from '@types';
 
 const fetchSelectStoreCoordinate = async (storeId: number) => {
-  try {
-    const response = await instance.get<ApiResponseType<StoreCoordinate>>(
-      END_POINT.FETCH_SELECT_STORE_COORDINATE(storeId)
-    );
-    return response.data.data;
-  } catch (error) {
-    console.log(error);
-    throw error;
-  }
+  const response = await instance.get<ApiResponseType<StoreCoordinate>>(
+    END_POINT.FETCH_SELECT_STORE_COORDINATE(storeId)
+  );
+  if (!response.data) return null;
+  return response.data.data;
 };
 
 export const useFetchSelectStoreCoordinate = (storeId: number) => {
   return useSuspenseQuery({
-    queryKey: [queryKey.SELECT_STORE_COORDINATE],
+    queryKey: [queryKey.SELECT_STORE_COORDINATE, storeId],
     queryFn: () => fetchSelectStoreCoordinate(storeId),
   });
 };

--- a/src/apis/store/useFetchStoreDetailDesign.ts
+++ b/src/apis/store/useFetchStoreDetailDesign.ts
@@ -13,15 +13,11 @@ import {
 const fetchStoreDetailDesign = async (
   storeId: number
 ): Promise<StoreDetailDesign[]> => {
-  try {
-    const response = await instance.get<
-      ApiResponseType<StoreDetailDesignResponse>
-    >(END_POINT.FETCH_STORE_DETAIL_DESIGN(storeId));
-    return response.data.data.storeDesignDtoList;
-  } catch (error) {
-    console.error();
-    throw error;
-  }
+  const response = await instance.get<
+    ApiResponseType<StoreDetailDesignResponse>
+  >(END_POINT.FETCH_STORE_DETAIL_DESIGN(storeId));
+  if (!response.data) return [];
+  return response.data.data.storeDesignDtoList;
 };
 
 export const useFetchStoreDetailDesign = (storeId: number) => {

--- a/src/apis/store/useFetchStoreDetailInfo.ts
+++ b/src/apis/store/useFetchStoreDetailInfo.ts
@@ -8,16 +8,12 @@ import { ApiResponseType, StoreDetailInfoResponse } from '@types';
 
 const fetchStoreDetailInfo = async (
   storeId: number
-): Promise<StoreDetailInfoResponse> => {
-  try {
-    const response = await instance.get<
-      ApiResponseType<StoreDetailInfoResponse>
-    >(END_POINT.FETCH_STORE_DETAIL_INFO(storeId));
-    return response.data.data;
-  } catch (error) {
-    console.error();
-    throw error;
-  }
+): Promise<StoreDetailInfoResponse | null> => {
+  const response = await instance.get<ApiResponseType<StoreDetailInfoResponse>>(
+    END_POINT.FETCH_STORE_DETAIL_INFO(storeId)
+  );
+  if (!response.data) return null;
+  return response.data.data;
 };
 
 export const useFetchStoreDetailInfo = (storeId: number) => {

--- a/src/apis/store/useFetchStoreDetailSize.ts
+++ b/src/apis/store/useFetchStoreDetailSize.ts
@@ -9,15 +9,15 @@ import { ApiResponseType, StoreDetailMenuResponse } from '@types';
 const fetchStoreDetailSize = async (
   storeId: number
 ): Promise<StoreDetailMenuResponse> => {
-  try {
-    const response = await instance.get<
-      ApiResponseType<StoreDetailMenuResponse>
-    >(END_POINT.FETCH_STORE_DETAIL_SIZE(storeId));
-    return response.data.data;
-  } catch (error) {
-    console.error();
-    throw error;
-  }
+  const response = await instance.get<ApiResponseType<StoreDetailMenuResponse>>(
+    END_POINT.FETCH_STORE_DETAIL_SIZE(storeId)
+  );
+  if (!response.data)
+    return {
+      sizeDtoList: [],
+      taste: '',
+    };
+  return response.data.data;
 };
 
 export const useFetchStoreDetailSize = (storeId: number) => {

--- a/src/apis/store/useFetchStoreInfo.ts
+++ b/src/apis/store/useFetchStoreInfo.ts
@@ -7,15 +7,13 @@ import { END_POINT, queryKey } from '@constants';
 import { ApiResponseType, StoreInfoResponse } from '@types';
 
 const fetchStoreInfo = async (storeId: number): Promise<StoreInfoResponse> => {
-  try {
-    const response = await instance.get<ApiResponseType<StoreInfoResponse>>(
-      END_POINT.FETCH_STORE_INFO(storeId)
-    );
-    return response.data.data;
-  } catch (error) {
-    console.error();
-    throw error;
+  const response = await instance.get<ApiResponseType<StoreInfoResponse>>(
+    END_POINT.FETCH_STORE_INFO(storeId)
+  );
+  if (!response.data) {
+    window.location.replace('/store');
   }
+  return response.data.data;
 };
 
 export const useFetchStoreInfo = (storeId: number) => {

--- a/src/apis/store/useFetchStoreLink.ts
+++ b/src/apis/store/useFetchStoreLink.ts
@@ -6,16 +6,12 @@ import { END_POINT, queryKey } from '@constants';
 
 import { ApiResponseType, StoreLinkResponse } from '@types';
 
-const fetchStoreLink = async (storeId: number): Promise<StoreLinkResponse> => {
-  try {
-    const response = await instance.get<ApiResponseType<StoreLinkResponse>>(
-      END_POINT.FETCH_STORE_LINK(storeId)
-    );
-    return response.data.data;
-  } catch (error) {
-    console.error();
-    throw error;
-  }
+const fetchStoreLink = async (storeId: number): Promise<string> => {
+  const response = await instance.get<ApiResponseType<StoreLinkResponse>>(
+    END_POINT.FETCH_STORE_LINK(storeId)
+  );
+  if (!response.data) return '';
+  return response.data.data.kakaoLink;
 };
 
 export const useFetchStoreLink = (storeId: number) => {

--- a/src/pages/store/components/BottomTab/BottomTab.tsx
+++ b/src/pages/store/components/BottomTab/BottomTab.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useFetchSelectStoreCoordinate, useFetchStoreLink } from '@apis/store';
 
 import { TextButton } from '@components';
+import { useToast } from '@contexts';
 
 import { container } from './BottomTab.css';
 
@@ -11,21 +12,26 @@ interface BottomTabProps {
 }
 
 const BottomTab = ({ storeId }: BottomTabProps) => {
+  const navigate = useNavigate();
+  const { showToast } = useToast();
+
   const { data: kakaoLink } = useFetchStoreLink(storeId);
   const { data: selectStoreCoordinate } =
     useFetchSelectStoreCoordinate(storeId);
 
-  const navigate = useNavigate();
-
   const handleMapViewClick = () => {
     if (selectStoreCoordinate) {
       navigate('/view', { state: { location: selectStoreCoordinate } });
+    } else {
+      showToast('error', '연결에 문제가 생겼어요');
     }
   };
 
   const handleOrderClick = () => {
     if (kakaoLink) {
       window.open(String(kakaoLink), '_blank');
+    } else {
+      showToast('error', '연결에 문제가 생겼어요');
     }
   };
 

--- a/src/pages/store/components/StoreInfo/StoreInfo.tsx
+++ b/src/pages/store/components/StoreInfo/StoreInfo.tsx
@@ -37,6 +37,8 @@ const StoreInfo = ({ storeId }: StoreInfoProps) => {
   const { isModalOpen, openModal, closeModal } = useModal();
   const [isToggleOpen, setIsToggleOpen] = useState(false);
 
+  if (!infoData) return null;
+
   const formattedHours = formatHours(infoData);
 
   const infoItems: InfoItem[] = [

--- a/src/pages/view/components/KakaoMap/KakaoMap.tsx
+++ b/src/pages/view/components/KakaoMap/KakaoMap.tsx
@@ -99,7 +99,7 @@ const KakaoMap = ({ currentLocation }: KakaoMapProps) => {
         />
       ) : (
         <Modal variant="bottom">
-          <SelectedStoreModal storeId={1} />
+          <SelectedStoreModal storeId={selectedStoreId} />
         </Modal>
       )}
     </>


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

### 📌 관련 이슈번호

- Closes #181
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

---

### 체크리스트

- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요? <!-- e.g. [Feat/#1] 로그인 기능 추가 -->
- [x] 🏗️ 빌드는 성공했나요? (yarn build)
- [x] 🧹 불필요한 코드는 제거했나요? e.g. console.log
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 
- [x] 🏷️ 라벨은 등록했나요?

---

### ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

**1. Axios interceptor 404 에러 처리**
40400, 40401을 제외한 데이터가 없어서 뜨는 404 에러의 경우, interceptor를 통해 null을 반환해 에러를 막고 각각의 API에서 기본값을 설정하는 로직을 구현했습니다. 선택 스토어 조회 API의 경우 기본값을 띄워주기 보다는 에러 페이지를 띄워주는 게 적절하다고 생각해 /store 페이지로 replace 되게 했습니다.

```
instance.interceptors.response.use(
  (response) => response,
  (error) => {
    const errorCodes = [40410, 40420, 40422, 40423, 40424];

    if (errorCodes.includes(error.response?.data?.code)) {
      return Promise.resolve({ data: null });
    }

    return Promise.reject(error);
  }
);
```

**2. 스토어 상세보기 관련 API에서 404 에러 기본값 처리했습니다.**


---

### 📢 To Reviewers

-

---

### 📸 스크린샷 or 실행영상
<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
