### PR TITLE
[Feat/#177] 토스트 띄우기

### DIFF
--- a/src/apis/likes/useDeleteCakeLikes.ts
+++ b/src/apis/likes/useDeleteCakeLikes.ts
@@ -3,6 +3,7 @@ import { useMutation } from '@tanstack/react-query';
 import { instance } from '@apis/instance';
 
 import { END_POINT, queryKey } from '@constants';
+import { useToast } from '@contexts';
 import queryClient from 'src/queryClient';
 
 import { MutateResposneType } from '@types';
@@ -20,6 +21,8 @@ const deleteCakeLikes = async (cakeId: number): Promise<MutateResposneType> => {
 };
 
 export const useDeleteCakeLikes = () => {
+  const { showToast } = useToast();
+
   return useMutation({
     mutationFn: (cakeId: number) => deleteCakeLikes(cakeId),
     onSuccess: () => {
@@ -27,6 +30,10 @@ export const useDeleteCakeLikes = () => {
         queryKey: [queryKey.STORE_DETAIL_DESIGN],
       });
       queryClient.invalidateQueries({ queryKey: [queryKey.LIKED_CAKE_LIST] });
+      showToast('check', '찜을 취소했어요', false);
+    },
+    onError: () => {
+      showToast('error', '연결에 문제가 생겼어요');
     },
   });
 };

--- a/src/apis/likes/useDeleteCakeLikes.ts
+++ b/src/apis/likes/useDeleteCakeLikes.ts
@@ -30,7 +30,7 @@ export const useDeleteCakeLikes = () => {
         queryKey: [queryKey.STORE_DETAIL_DESIGN],
       });
       queryClient.invalidateQueries({ queryKey: [queryKey.LIKED_CAKE_LIST] });
-      showToast('check', '찜을 취소했어요', false);
+      showToast('check', '찜을 취소했어요');
     },
     onError: () => {
       showToast('error', '연결에 문제가 생겼어요');

--- a/src/apis/likes/useDeleteStoreLikes.ts
+++ b/src/apis/likes/useDeleteStoreLikes.ts
@@ -3,6 +3,7 @@ import { useMutation } from '@tanstack/react-query';
 import { instance } from '@apis/instance';
 
 import { END_POINT, queryKey } from '@constants';
+import { useToast } from '@contexts';
 import queryClient from 'src/queryClient';
 
 import { MutateResposneType } from '@types';
@@ -22,6 +23,8 @@ const deleteStoreLikes = async (
 };
 
 export const useDeleteStoreLikes = () => {
+  const { showToast } = useToast();
+
   return useMutation({
     mutationFn: (storeId: number) => deleteStoreLikes(storeId),
     onSuccess: () => {
@@ -29,6 +32,10 @@ export const useDeleteStoreLikes = () => {
         queryKey: [queryKey.STORE_INFO],
       });
       queryClient.invalidateQueries({ queryKey: [queryKey.LIKED_STORE_LIST] });
+      showToast('check', '찜을 취소했어요', false);
+    },
+    onError: () => {
+      showToast('error', '연결에 문제가 생겼어요');
     },
   });
 };

--- a/src/apis/likes/useDeleteStoreLikes.ts
+++ b/src/apis/likes/useDeleteStoreLikes.ts
@@ -32,7 +32,7 @@ export const useDeleteStoreLikes = () => {
         queryKey: [queryKey.STORE_INFO],
       });
       queryClient.invalidateQueries({ queryKey: [queryKey.LIKED_STORE_LIST] });
-      showToast('check', '찜을 취소했어요', false);
+      showToast('check', '찜을 취소했어요');
     },
     onError: () => {
       showToast('error', '연결에 문제가 생겼어요');

--- a/src/apis/likes/usePostCakeLikes.ts
+++ b/src/apis/likes/usePostCakeLikes.ts
@@ -3,6 +3,7 @@ import { useMutation } from '@tanstack/react-query';
 import { instance } from '@apis/instance';
 
 import { END_POINT, queryKey } from '@constants';
+import { useToast } from '@contexts';
 import queryClient from 'src/queryClient';
 
 import { MutateResposneType } from '@types';
@@ -17,6 +18,8 @@ const postCakeLikes = async (cakeId: number): Promise<MutateResposneType> => {
   }
 };
 export const usePostCakeLikes = () => {
+  const { showToast } = useToast();
+
   return useMutation({
     mutationFn: (cakeId: number) => postCakeLikes(cakeId),
     onSuccess: () => {
@@ -24,6 +27,10 @@ export const usePostCakeLikes = () => {
         queryKey: [queryKey.STORE_DETAIL_DESIGN],
       });
       queryClient.invalidateQueries({ queryKey: [queryKey.LIKED_CAKE_LIST] });
+      showToast('like', '케이크를 찜했어요', true);
+    },
+    onError: () => {
+      showToast('error', '연결에 문제가 생겼어요');
     },
   });
 };

--- a/src/apis/likes/usePostCakeLikes.ts
+++ b/src/apis/likes/usePostCakeLikes.ts
@@ -10,7 +10,7 @@ import { MutateResposneType } from '@types';
 
 const postCakeLikes = async (cakeId: number): Promise<MutateResposneType> => {
   try {
-    const response = await instance.post(END_POINT.DELETE_LIKE('cake', cakeId));
+    const response = await instance.post(END_POINT.POST_LIKE('cake', cakeId));
     return response.data;
   } catch (error) {
     console.log(error);

--- a/src/apis/likes/usePostCakeLikes.ts
+++ b/src/apis/likes/usePostCakeLikes.ts
@@ -27,7 +27,13 @@ export const usePostCakeLikes = () => {
         queryKey: [queryKey.STORE_DETAIL_DESIGN],
       });
       queryClient.invalidateQueries({ queryKey: [queryKey.LIKED_CAKE_LIST] });
-      showToast('like', '케이크를 찜했어요', true);
+
+      showToast(
+        'like',
+        '케이크를 찜했어요',
+        true,
+        '/mypage/like-list?tab=cake'
+      );
     },
     onError: () => {
       showToast('error', '연결에 문제가 생겼어요');

--- a/src/apis/likes/usePostStoreLikes.ts
+++ b/src/apis/likes/usePostStoreLikes.ts
@@ -28,7 +28,12 @@ export const usePostStoreLikes = () => {
         queryKey: [queryKey.STORE_INFO],
       });
       queryClient.invalidateQueries({ queryKey: [queryKey.LIKED_STORE_LIST] });
-      showToast('save', '스토어를 찜했어요', true);
+
+      showToast(
+        'save',
+        '스토어를 찜했어요',
+        true,
+      );
     },
     onError: () => {
       showToast('error', '연결에 문제가 생겼어요');

--- a/src/apis/likes/usePostStoreLikes.ts
+++ b/src/apis/likes/usePostStoreLikes.ts
@@ -29,12 +29,7 @@ export const usePostStoreLikes = () => {
       });
       queryClient.invalidateQueries({ queryKey: [queryKey.LIKED_STORE_LIST] });
 
-      showToast(
-        'save',
-        '스토어를 찜했어요',
-        true,
-        '/mypage/like-list?tab=store'
-      );
+      showToast('save', '스토어를 찜했어요', true, '/mypage/like-list');
     },
     onError: () => {
       showToast('error', '연결에 문제가 생겼어요');

--- a/src/apis/likes/usePostStoreLikes.ts
+++ b/src/apis/likes/usePostStoreLikes.ts
@@ -33,6 +33,7 @@ export const usePostStoreLikes = () => {
         'save',
         '스토어를 찜했어요',
         true,
+        '/mypage/like-list?tab=store'
       );
     },
     onError: () => {

--- a/src/apis/likes/usePostStoreLikes.ts
+++ b/src/apis/likes/usePostStoreLikes.ts
@@ -3,6 +3,7 @@ import { useMutation } from '@tanstack/react-query';
 import { instance } from '@apis/instance';
 
 import { END_POINT, queryKey } from '@constants';
+import { useToast } from '@contexts';
 import queryClient from 'src/queryClient';
 
 import { MutateResposneType } from '@types';
@@ -18,6 +19,8 @@ const postStoreLikes = async (storeId: number): Promise<MutateResposneType> => {
 };
 
 export const usePostStoreLikes = () => {
+  const { showToast } = useToast();
+
   return useMutation({
     mutationFn: (storeId: number) => postStoreLikes(storeId),
     onSuccess: () => {
@@ -25,6 +28,10 @@ export const usePostStoreLikes = () => {
         queryKey: [queryKey.STORE_INFO],
       });
       queryClient.invalidateQueries({ queryKey: [queryKey.LIKED_STORE_LIST] });
+      showToast('save', '스토어를 찜했어요', true);
+    },
+    onError: () => {
+      showToast('error', '연결에 문제가 생겼어요');
     },
   });
 };

--- a/src/components/common/Toast/Toast.tsx
+++ b/src/components/common/Toast/Toast.tsx
@@ -5,7 +5,6 @@ import { IcLineLikeOn20, IcSavedOn24, IcToastCheck, IcToastError } from '@svgs';
 
 import { toastButtonStyle, toastMessageStyle, toastStyle } from './Toast.css';
 
-
 import { ToastState } from '@types';
 
 const toastVariants = {
@@ -49,7 +48,14 @@ const Toast = ({ icon, message, isButton = false }: ToastState) => {
         {toastIcon[icon]}
         <span>{message}</span>
       </div>
-      {isButton && <button className={toastButtonStyle}>보러가기</button>}
+      {isButton && (
+        <button
+          className={toastButtonStyle}
+          onClick={() => (window.location.href = '/mypage/like-list')}
+        >
+          보러가기
+        </button>
+      )}
     </motion.dialog>,
     portalElement
   );

--- a/src/components/common/Toast/Toast.tsx
+++ b/src/components/common/Toast/Toast.tsx
@@ -34,7 +34,7 @@ const toastIcon = {
 
 const portalElement = document.getElementById('toast') as HTMLElement;
 
-const Toast = ({ icon, message, isButton = false }: ToastState) => {
+const Toast = ({ icon, message, isButton = false, targetPath }: ToastState) => {
   return createPortal(
     <motion.dialog
       className={toastStyle({ isButton })}
@@ -48,10 +48,10 @@ const Toast = ({ icon, message, isButton = false }: ToastState) => {
         {toastIcon[icon]}
         <span>{message}</span>
       </div>
-      {isButton && (
+      {isButton && targetPath && (
         <button
           className={toastButtonStyle}
-          onClick={() => (window.location.href = '/mypage/like-list')}
+          onClick={() => (window.location.href = targetPath)}
         >
           보러가기
         </button>

--- a/src/contexts/ToastContext.tsx
+++ b/src/contexts/ToastContext.tsx
@@ -9,7 +9,12 @@ import { ToastState, ToastType } from '@types';
 const TOAST_REMOVE_DELAY = 2000;
 
 interface ToastContextType {
-  showToast: (icon: ToastType, message: string, isButton?: boolean) => void;
+  showToast: (
+    icon: ToastType,
+    message: string,
+    isButton?: boolean,
+    targetPath?: string
+  ) => void;
 }
 
 const ToastContext = createContext<ToastContextType | undefined>(undefined);
@@ -23,8 +28,13 @@ export const ToastProvider = ({ children }: ToastProviderProps) => {
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const showToast = useCallback(
-    (icon: ToastType, message: string, isButton?: boolean) => {
-      setToast({ icon, message, isButton });
+    (
+      icon: ToastType,
+      message: string,
+      isButton?: boolean,
+      targetPath?: string
+    ) => {
+      setToast({ icon, message, isButton, targetPath });
 
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
@@ -46,6 +56,7 @@ export const ToastProvider = ({ children }: ToastProviderProps) => {
             icon={toast.icon}
             message={toast.message}
             isButton={toast.isButton}
+            targetPath={toast.targetPath}
           />
         )}
       </AnimatePresence>

--- a/src/pages/myPage/page/MyList/LikeListPage.tsx
+++ b/src/pages/myPage/page/MyList/LikeListPage.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 
 import { useFetchLikedCakeList, useFetchLikedStoreList } from '@apis/myPage';
 
@@ -14,7 +15,18 @@ import {
 } from './LikeListPage.css';
 
 const LikeListPage = () => {
+  const [searchParams] = useSearchParams();
   const [activeTab, setActiveTab] = useState(0);
+
+  useEffect(() => {
+    const tabParam = searchParams.get('tab');
+    console.log(tabParam);
+    if (tabParam === 'store') {
+      setActiveTab(0);
+    } else if (tabParam === 'cake') {
+      setActiveTab(1);
+    }
+  }, [searchParams]);
 
   const handleTab = (index: number) => {
     setActiveTab(index);

--- a/src/types/toastType.ts
+++ b/src/types/toastType.ts
@@ -4,4 +4,5 @@ export interface ToastState {
   icon: ToastType;
   message: string;
   isButton?: boolean;
+  targetPath?: string; 
 }


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

### 📌 관련 이슈번호

- Closes #177 
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

---

### 체크리스트

- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요? <!-- e.g. [Feat/#1] 로그인 기능 추가 -->
- [x] 🏗️ 빌드는 성공했나요? (yarn build)
- [x] 🧹 불필요한 코드는 제거했나요? e.g. console.log
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 
- [x] 🏷️ 라벨은 등록했나요?

---

### ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- 토스트 띄우기에 성공했습니다.
- 스토어 저장을 누르면 토스트가 뜨고, 토스트에는 '보러가기' 버튼이 있습니다.
- 스토어 save 버튼을 누른 후 토스트의 '보러가기' 버튼을 누르면 찜목록의 '스토어 탭' 뷰로 넘어갑니다.
- 케이크 like 버튼을 누른 후 토스트의 '보러가기' 버튼을 누르면 찜목록의 '디자인 탭' 뷰로 넘어갑니다.
---

### 📢 To Reviewers

- 스토어 저장을 누르면 찜 목록의 '스토어 탭'으로 이동하고, 케이크 좋아요를 누르면 '디자인 탭'으로 이동할 수 있도록 하는 것을 조금 더 고민한 뒤에 수정해보겠습니다.
-> (1/23 | 22시50분 성공했습니다)

---
