### PR TITLE
[Feat/#184] 로그인 없이 필요한 기능 실행 시 로그인 모달 띄우기

### DIFF
--- a/src/components/common/AuthModal/AuthModal.tsx
+++ b/src/components/common/AuthModal/AuthModal.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import { useDeleteLogout } from '@apis/auth';
 
 import { useEasyNavigate } from '@hooks';
@@ -21,7 +23,12 @@ const AuthModal = ({
   const { mutate: logout } = useDeleteLogout();
   const { goLoginPage } = useEasyNavigate();
 
-  const handleActionButtonClick = () => {
+  const handleCloseClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    onClose();
+  };
+  const handleActionButtonClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
     if (authActionButtonText === '로그아웃') {
       logout();
     } else {
@@ -32,7 +39,7 @@ const AuthModal = ({
     <div className={authModalContainer}>
       <h1 className={modalMessage}>{modalText}</h1>
       <div className={buttonSet}>
-        <TextButton size={'small'} color={'gray'} onClick={onClose}>
+        <TextButton size={'small'} color={'gray'} onClick={handleCloseClick}>
           {closeButtonText}
         </TextButton>
         <TextButton

--- a/src/hooks/useEasyNavigate.ts
+++ b/src/hooks/useEasyNavigate.ts
@@ -35,6 +35,10 @@ const useEasyNavigate = () => {
     navigate(routePath.LOGINPAGE);
   };
 
+  const goBack = () => {
+    navigate(-1);
+  };
+
   return {
     goHomePage,
     goViewPage,
@@ -43,6 +47,7 @@ const useEasyNavigate = () => {
     goStorePage,
     goDesignListPage,
     goLoginPage,
+    goBack,
   };
 };
 

--- a/src/pages/auth/page/LoginPage/LoginPage.css.ts
+++ b/src/pages/auth/page/LoginPage/LoginPage.css.ts
@@ -33,5 +33,5 @@ export const loginButtonWrapper = style([
 
 export const noLoginButton = style([
   vars.fonts.body07_r_14,
-  { color: vars.colors.gray900 },
+  { color: vars.colors.gray900, cursor: 'pointer' },
 ]);

--- a/src/pages/auth/page/LoginPage/LoginPage.tsx
+++ b/src/pages/auth/page/LoginPage/LoginPage.tsx
@@ -18,7 +18,7 @@ import {
 } from './LoginPage.css';
 
 const LoginPage = () => {
-  const { goHomePage } = useEasyNavigate();
+  const { goHomePage, goBack } = useEasyNavigate();
   const kakaoLoginUrl = `https://kauth.kakao.com/oauth/authorize?client_id=${
     import.meta.env.VITE_REST_API_KEY
   }&redirect_uri=${import.meta.env.VITE_REDIRECT_URI}&response_type=code`;
@@ -47,7 +47,9 @@ const LoginPage = () => {
           <SocialLoginButton platform="kakao" onClick={handleLoginClick}>
             카카오로 시작하기
           </SocialLoginButton>
-          <u className={noLoginButton}>로그인 없이 둘러보기</u>
+          <u className={noLoginButton} onClick={goBack}>
+            로그인 없이 둘러보기
+          </u>
         </div>
       </div>
     </div>

--- a/src/types/apis/commonType.ts
+++ b/src/types/apis/commonType.ts
@@ -16,3 +16,8 @@ export interface ErrorResponse {
     status: number;
   };
 }
+
+export interface ErrorType {
+  status?: number;
+  message: string;
+}


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

### 📌 관련 이슈번호

- Closes #184 
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

---

### 체크리스트

- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요? <!-- e.g. [Feat/#1] 로그인 기능 추가 -->
- [x] 🏗️ 빌드는 성공했나요? (yarn build)
- [x] 🧹 불필요한 코드는 제거했나요? e.g. console.log
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 
- [x] 🏷️ 라벨은 등록했나요?

---

### ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. IconButton에서 post요청시에 로그인이 안되어있으면 로그인 필요 모달 띄웠습니다.
   - 해당 과정에서 기존에 낙관적 업데이트를 위해 post요청을 실패하면 onError에 의해 rollBackUpdate를 합니다.
   - 이때 에러 status가 401이면 로그인이 필요하다는 모달을 openModal()로 띄워줍니다.
   - 이 과정에서 원래는 IconButton의 클릭이벤트에 e.stopPropagation()으로 이벤트 전파를 막아놨는데도 상위 컴포넌트로 이벤트가 전달되는 이슈가 있었습니다. 
   - 해결방법은 AuthModal에 있는 두개의 버튼에 모두 e.stopPropagation()으로 이벤트 전파를 한번 더 막아줘야만 했습니다.
2. 로그인 없이 둘러보기 클릭했을 때는 그 전페이지로 이동시켰습니다.


---

### 📢 To Reviewers

-

---

### 📸 스크린샷 or 실행영상
<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
