### PR TITLE
[Fix/#202] 웹파트 내부 QA 2차 수정

### DIFF
--- a/src/components/common/BottomSheet/BottomSheet.css.ts
+++ b/src/components/common/BottomSheet/BottomSheet.css.ts
@@ -14,7 +14,7 @@ export const bottomSheetStyle = style([
   fixedGenerator({ bottom: 0 }, 2),
   {
     height: '79vh',
-    padding: '1.4rem 2rem 0',
+    paddingTop: '1.4rem',
 
     backgroundColor: vars.colors.white,
     borderRadius: '20px 20px 0 0',

--- a/src/components/common/CardList/CardList.css.ts
+++ b/src/components/common/CardList/CardList.css.ts
@@ -60,7 +60,7 @@ export const cardListNullTextStyle = style([
   {
     color: vars.colors.gray400,
     width: '100%',
-    height: 'calc(100dvh - 23.6rem - 1.2rem)',
+    height: 'calc(100dvh - 23.6rem - 1.2rem - 20rem)',
   },
 ]);
 

--- a/src/components/common/Modal/Modal.css.ts
+++ b/src/components/common/Modal/Modal.css.ts
@@ -1,21 +1,28 @@
-import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
 import { fixedGenerator, flexGenerator } from '@styles/generator.css';
 import { vars } from '@styles/theme.css';
 
-export const backdropStyle = style([
-  fixedGenerator({ top: 0, center: true }, 3),
-  {
-    height: '100%',
-    background: vars.colors.dimmed,
-  },
-]);
+export const backdropStyle = recipe({
+  base: [
+    fixedGenerator({ top: 0, center: true }),
+    {
+      height: '100%',
+      background: vars.colors.dimmed,
+    },
+  ],
+  variants: {
+    variant: {
+      center: {zIndex: 5},
+      bottom: {zIndex: 3}
+    }
+  }
+})
 
 export const modalStyle = recipe({
   base: [
     flexGenerator(),
-    { zIndex: 4, backgroundColor: vars.colors.white, position: 'fixed' },
+    {backgroundColor: vars.colors.white, position: 'fixed' },
   ],
   variants: {
     variant: {
@@ -24,12 +31,14 @@ export const modalStyle = recipe({
         left: '50%',
         transform: 'translate(-50%, -50%)',
         borderRadius: '10px',
+        zIndex: 5, 
       },
       bottom: [
         fixedGenerator({ bottom: 0, center: true }, 4),
         {
           borderRadius: '10px 10px 0px 0px',
           boxShadow: '0px 0px 20px 0px rgba(0, 0, 0, 0.10)',
+          zIndex: 4
         },
       ],
     },

--- a/src/components/common/Modal/Modal.tsx
+++ b/src/components/common/Modal/Modal.tsx
@@ -19,7 +19,9 @@ const Modal = ({
 }: PropsWithChildren<ModalProps>) => {
   return createPortal(
     <>
-      {hasBackdrop && <div className={backdropStyle} onClick={backdropClick} />}
+      {hasBackdrop && (
+        <div className={backdropStyle({ variant })} onClick={backdropClick} />
+      )}
       <div className={modalStyle({ variant })}>{children}</div>
     </>,
     potalElement

--- a/src/pages/myPage/page/MyList/LikeListPage.tsx
+++ b/src/pages/myPage/page/MyList/LikeListPage.tsx
@@ -28,11 +28,12 @@ const LikeListPage = () => {
     }
   }, [searchParams]);
 
+  const { option, handleOptionSelect } = useFilteredCardList();
+
   const handleTab = (index: number) => {
     setActiveTab(index);
+    handleOptionSelect('latest');
   };
-
-  const { option, handleOptionSelect } = useFilteredCardList();
 
   const isStoreListEnabled = activeTab === 0;
   const isCakeListEnabled = activeTab === 1;

--- a/src/pages/view/components/MapBottomSheet/MapBottomSheet.css.ts
+++ b/src/pages/view/components/MapBottomSheet/MapBottomSheet.css.ts
@@ -5,6 +5,7 @@ import { flexGenerator } from '@styles/generator.css';
 export const listContainer = style({
   paddingBottom: '1.4rem',
   width: '100%',
+  padding: '0rem 2rem',
 });
 
 export const sectionContainer = style([

--- a/src/pages/view/components/MapBottomSheet/MapBottomSheet.tsx
+++ b/src/pages/view/components/MapBottomSheet/MapBottomSheet.tsx
@@ -38,6 +38,7 @@ const MapBottomSheet = ({
 
   const handleTab = (index: number) => {
     setActiveTab(index);
+    handleOptionSelect('latest');
   };
 
   // 스토어 정보 리스트 조회


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

### 📌 관련 이슈번호

- Closes #202
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

---

### 체크리스트

- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요? <!-- e.g. [Feat/#1] 로그인 기능 추가 -->
- [x] 🏗️ 빌드는 성공했나요? (yarn build)
- [x] 🧹 불필요한 코드는 제거했나요? e.g. console.log
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 
- [x] 🏷️ 라벨은 등록했나요?

---

### ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 등록된 스토어가 없는 지하철역을 조회했을 때, “등록된 스토어가 아직 없어요” 라는 문구가 화면 하단 바닥에 뜨는 이슈
- 해당 문구가 20rem 정도 위로 올라오도록 수정했습니다. 디자이너 분들께 여쭤봤을 때, 다른 페이지에서 가운데에 뜨는게 더 좋지만, 우선순위가 아니니 일단 이정도로 해달라고 하심! > 추후에는 바텀시트가 중간 위치에 있을 때 / 바텀시트가 완전히 열려있을 때 + 마이페이지처럼 하나의 페이지 에 뜰 때 위치가 다르도록 수정이 되면 좋을듯


2. 모달이 두 개 올라왔을 때 겹치는 이슈
- center 모달과 bottom 모달의 z-index를 다르게 주는 형태로 해서, center 모달이 더 위에 뜨도록 수정했습니다.


3. 탭 바꿀 때 필터링 최신순으로 버튼 초기화되도록 수정
- 탭이 바뀌는 핸들 함수 안에서 필터링 핸들 함수를 실행시켜서, 탭이 바뀔 때마다 option 값이 '최신순'이 되도록 수정했습니다.


4. 필터링 버튼 오른쪽 shadow 안 먹는 이슈
- 바텀시트가 가지고 있는 padding이 있어서, 바텀시트의 양 옆 padding을 없애고 MapBottomSheet에 양 옆 padding을 주는 형식으로 수정했습니다.


---

### 📢 To Reviewers

-

---

### 📸 스크린샷 or 실행영상
<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
