### PR TITLE
[Feat/228] 최근 본 디자인 추적 기능 구현

### DIFF
--- a/src/components/common/DesignCard/DesignCard.tsx
+++ b/src/components/common/DesignCard/DesignCard.tsx
@@ -39,7 +39,7 @@ const DesignCard = ({
     isLiked,
   } = designItem;
 
-  const { goStorePage } = useEasyNavigate();
+  const { goStorePageByCakeId } = useEasyNavigate();
 
   const { openModal, isModalOpen, closeModal } = useModal();
 
@@ -47,7 +47,7 @@ const DesignCard = ({
     if (hasModal) {
       openModal(); // 둘러보기 페이지에서는 모달 띄우기
     } else {
-      goStorePage(storeId); // 나머지 페이지에선 상세보기로 이동
+      goStorePageByCakeId(storeId, cakeId); // 나머지 페이지에선 상세보기로 이동
     }
   };
 

--- a/src/hooks/useEasyNavigate.ts
+++ b/src/hooks/useEasyNavigate.ts
@@ -31,6 +31,12 @@ const useEasyNavigate = () => {
     navigate(routePath.STOREPAGE.replace(':id', String(storeId)));
   };
 
+  const goStorePageByCakeId = (storeId: number, cakeId: number) => {
+    navigate(routePath.STOREPAGE.replace(':id', String(storeId)), {
+      state: { cakeId },
+    });
+  };
+
   const goDesignListPage = (category: CategoryType) => {
     navigate(routePath.DESIGNLISTPAGE, { state: { category } });
   };
@@ -50,6 +56,7 @@ const useEasyNavigate = () => {
     goLikeListPage,
     goLikeListPageByTab,
     goStorePage,
+    goStorePageByCakeId,
     goDesignListPage,
     goLoginPage,
     goBack,

--- a/src/pages/store/components/StoreDesign/StoreDesign.css.ts
+++ b/src/pages/store/components/StoreDesign/StoreDesign.css.ts
@@ -1,10 +1,28 @@
 import { style } from '@vanilla-extract/css';
 
+import { vars } from '@styles/theme.css';
+
 export const gridStyle = style({
   display: 'grid',
   gridTemplateColumns: '1fr 1fr',
 });
 
 export const liStyle = style({
+  position: 'relative',
   cursor: 'pointer',
 });
+
+export const dimmedStyle = style([
+  vars.fonts.body02_sb_14,
+  {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+    alignContent: 'center',
+    textAlign: 'center',
+    backgroundColor: vars.colors.dimmed,
+    color: vars.colors.white,
+  },
+]);

--- a/src/pages/store/components/StoreDesign/StoreDesign.tsx
+++ b/src/pages/store/components/StoreDesign/StoreDesign.tsx
@@ -1,17 +1,18 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { useFetchStoreDetailDesign } from '@apis/store';
 
 import { Image, Modal } from '@components';
 
-import { gridStyle, liStyle } from './StoreDesign.css';
+import { gridStyle, liStyle, dimmedStyle } from './StoreDesign.css';
 import ImageModal from '../ImageModal/ImageModal';
 
 interface StoreDesignProps {
   storeId: number;
+  recentCakeId?: number;
 }
 
-const StoreDesign = ({ storeId }: StoreDesignProps) => {
+const StoreDesign = ({ storeId, recentCakeId }: StoreDesignProps) => {
   const { data: designData } = useFetchStoreDetailDesign(storeId);
 
   const [selectedImage, setSelectedImage] = useState<string | null>(null);
@@ -23,6 +24,21 @@ const StoreDesign = ({ storeId }: StoreDesignProps) => {
   const closeImageModal = () => {
     setSelectedImage(null);
   };
+
+  const recentCakeRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (recentCakeId && recentCakeRef.current) {
+      const scrollToCake = () => {
+        recentCakeRef.current?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'center',
+        });
+      };
+
+      requestAnimationFrame(scrollToCake);
+    }
+  }, [recentCakeId]);
 
   return (
     <>
@@ -39,6 +55,11 @@ const StoreDesign = ({ storeId }: StoreDesignProps) => {
               isActive={design.isLiked}
               itemId={design.cakeId}
             />
+            {recentCakeId === design.cakeId && (
+              <div ref={recentCakeRef} className={dimmedStyle}>
+                방금 본 케이크
+              </div>
+            )}
           </li>
         ))}
       </ul>

--- a/src/pages/store/page/StorePage/StorePage.tsx
+++ b/src/pages/store/page/StorePage/StorePage.tsx
@@ -1,5 +1,5 @@
 import { startTransition, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router-dom';
 
 import { useFetchStoreInfo } from '@apis/store';
 
@@ -14,8 +14,10 @@ import { sectionStyle } from './StorePage.css';
 
 const StorePage = () => {
   const storeId = Number(useParams<{ id: string }>().id);
-
   const { data: storeData } = useFetchStoreInfo(storeId);
+
+  const location = useLocation();
+  const [recentCakeId, setRecentCakeId] = useState(location.state?.cakeId);
 
   const [activeTab, setActiveTab] = useState(0);
 
@@ -23,10 +25,12 @@ const StorePage = () => {
     startTransition(() => {
       setActiveTab(index);
     });
+
+    setRecentCakeId(null);
   };
 
   const tabComponents = [
-    <StoreDesign storeId={storeId} />,
+    <StoreDesign storeId={storeId} recentCakeId={recentCakeId} />,
     <StoreMenu storeId={storeId} />,
     <StoreInfo storeId={storeId} />,
   ];


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

### 📌 관련 이슈번호

- Closes #228
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

---

### 체크리스트

- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요? <!-- e.g. [Feat/#1] 로그인 기능 추가 -->
- [x] 🏗️ 빌드는 성공했나요? (yarn build)
- [x] 🧹 불필요한 코드는 제거했나요? e.g. console.log
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 
- [x] 🏷️ 라벨은 등록했나요?

---

### ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

**1. 최근 본 디자인 추적 기능 구현**
- 찜 디자인 탭, 메인 페이지 인기 디자인을 클릭할 경우 상세 페이지로 이동하며, 클릭한 디자인을 "방금 본 케이크"로 표시하는 기능입니다.
- 케이크 id를 state로 넘기기 위해 `goStorePageByCakeId`라는 네비게이트 함수를 추가했습니다.
- 상세 페이지 내에서 탭을 전환했을 때 다시 아래로 자동 스크롤되는 것을 방지하기 위해 recentCakeId 값을 관리하고 탭 변경 시 초기화해줬습니다.
- 상세 페이지로 이동하면 방금 본 디자인으로 바로 스크롤이 되어야 하는데 함수를 실행시켜도 스크롤 되지 않는 오류가 있었습니다. 페이지가 완전히 그려지지 않은 상태에서 함수가 실행되어 발생하는 오류라고 판단해 requestAnimationFrame을 활용하여 브라우저가 리페인트되는 시점에 맞춰 스크롤 함수가 실행되도록 구현하여 해결했습니다.

---

### 📢 To Reviewers

-

---

### 📸 스크린샷 or 실행영상
<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
