### PR TITLE
[Feat/#229] 지도뷰 모달 flow 수정 및 지도뷰 선택 디자인 조회 api 요청

### DIFF
--- a/src/apis/view/index.ts
+++ b/src/apis/view/index.ts
@@ -1,3 +1,4 @@
+import { useFetchCakeInfo } from './useFetchCakeInfo';
 import { useFetchLikedStoreDesign } from './useFetchLikedStoreDesign';
 import { useFetchLikesStoreCoordinate } from './useFetchLikesStoreCoordinate';
 import { useFetchStationDesign } from './useFetchStationDesign';
@@ -12,4 +13,5 @@ export {
   useFetchStationStore,
   useFetchStationDesign,
   useFetchLikedStoreDesign,
+  useFetchCakeInfo,
 };

--- a/src/apis/view/useFetchCakeInfo.ts
+++ b/src/apis/view/useFetchCakeInfo.ts
@@ -1,0 +1,35 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import { instance } from '@apis/instance';
+
+import { END_POINT, queryKey } from '@constants';
+
+import { ApiResponseType, CakeInfoResponse } from '@types';
+
+const fetchCakeInfo = async (
+  cakeId: number
+): Promise<CakeInfoResponse | null> => {
+//   try {
+//     const response = await instance.get<ApiResponseType<CakeInfoResponse>>(
+//       END_POINT.FETCH_CAKE_INFO(cakeId)
+//     );
+//     return response.data?.data ?? null;
+//   } catch (error) {
+//     console.log(error);
+//     // if (error.response?.data?.code === 40410){
+//     //     return null
+//     // }
+//     throw error;
+//   }
+const response = await instance.get<ApiResponseType<CakeInfoResponse>>(
+    END_POINT.FETCH_CAKE_INFO(cakeId)
+  );
+  return response.data?.data ?? null;
+};
+
+export const useFetchCakeInfo = (cakeId: number) => {
+  return useSuspenseQuery({
+    queryKey: [queryKey.CAKE_INFO, cakeId],
+    queryFn: () => fetchCakeInfo(cakeId),
+  });
+};

--- a/src/components/common/CardList/CardList.tsx
+++ b/src/components/common/CardList/CardList.tsx
@@ -22,6 +22,7 @@ import {
   DesignItemType,
   ItemType,
   OptionType,
+  SelectedModalType,
   StoreCardListType,
   StoreType,
   SubCategoryType,
@@ -38,7 +39,7 @@ interface CardListProps {
     subCategory: SubCategoryType;
   };
   fetchNextPage: () => void;
-  onSelectStore: (storeId: number) => void;
+  onSelectStore: ({storeId, cakeId}: SelectedModalType) => void;
 }
 
 const CardList = ({

--- a/src/components/common/CardList/CardList.tsx
+++ b/src/components/common/CardList/CardList.tsx
@@ -38,6 +38,7 @@ interface CardListProps {
     subCategory: SubCategoryType;
   };
   fetchNextPage: () => void;
+  onSelectStore: (storeId: number) => void;
 }
 
 const CardList = ({
@@ -48,6 +49,7 @@ const CardList = ({
   hasModal,
   selectedCategories,
   fetchNextPage,
+  onSelectStore,
 }: CardListProps) => {
   const { ref, inView } = useInView();
 
@@ -133,7 +135,11 @@ const CardList = ({
           {item === 'store' || item === 'likedStore' ? (
             <div className={storeCardListWrapper}>
               {(cardListData as StoreType[]).map((store) => (
-                <StoreCard storeItem={store} key={store.storeId} />
+                <StoreCard
+                  storeItem={store}
+                  key={store.storeId}
+                  onSelectStore={onSelectStore}
+                />
               ))}
             </div>
           ) : (
@@ -144,6 +150,7 @@ const CardList = ({
                   designItem={cake}
                   hasModal={hasModal}
                   selectedCategories={selectedCategories}
+                  onSelectStore={onSelectStore}
                 />
               ))}
             </div>

--- a/src/components/common/CardList/CardList.tsx
+++ b/src/components/common/CardList/CardList.tsx
@@ -39,7 +39,7 @@ interface CardListProps {
     subCategory: SubCategoryType;
   };
   fetchNextPage: () => void;
-  onSelectStore: ({storeId, cakeId}: SelectedModalType) => void;
+  onSelectStore?: ({storeId, cakeId}: SelectedModalType) => void;
 }
 
 const CardList = ({

--- a/src/components/common/DesignCard/DesignCard.tsx
+++ b/src/components/common/DesignCard/DesignCard.tsx
@@ -21,6 +21,7 @@ interface DesignCardProps extends HTMLAttributes<HTMLDivElement> {
     category: CategoryType;
     subCategory: SubCategoryType;
   };
+  onSelectStore: (storeId: number) => void;
 }
 
 const DesignCard = ({
@@ -28,6 +29,7 @@ const DesignCard = ({
   numberLabel,
   hasModal = false,
   selectedCategories,
+  onSelectStore,
 }: DesignCardProps) => {
   const {
     cakeId,
@@ -47,7 +49,8 @@ const DesignCard = ({
     if (hasModal) {
       openModal(); // 둘러보기 페이지에서는 모달 띄우기
     } else {
-      goStorePage(storeId); // 나머지 페이지에선 상세보기로 이동
+      onSelectStore(storeId);
+      // goStorePage(storeId); // 나머지 페이지에선 상세보기로 이동
     }
   };
 
@@ -71,7 +74,10 @@ const DesignCard = ({
 
       {isModalOpen && (
         <Modal variant="bottom" hasBackdrop backdropClick={closeModal}>
-          <DesignSearchModal cakeId={cakeId} selectedCategories={selectedCategories} />
+          <DesignSearchModal
+            cakeId={cakeId}
+            selectedCategories={selectedCategories}
+          />
         </Modal>
       )}
     </>

--- a/src/components/common/DesignCard/DesignCard.tsx
+++ b/src/components/common/DesignCard/DesignCard.tsx
@@ -21,7 +21,7 @@ interface DesignCardProps extends HTMLAttributes<HTMLDivElement> {
     category: CategoryType;
     subCategory: SubCategoryType;
   };
-  onSelectStore: (storeId: number) => void;
+  onSelectStore?: (storeId: number) => void;
 }
 
 const DesignCard = ({
@@ -48,9 +48,10 @@ const DesignCard = ({
   const handleCardClick = () => {
     if (hasModal) {
       openModal(); // 둘러보기 페이지에서는 모달 띄우기
-    } else {
+    } else if (onSelectStore) {
       onSelectStore(storeId);
-      // goStorePage(storeId); // 나머지 페이지에선 상세보기로 이동
+    } else {
+      goStorePage(storeId); // 나머지 페이지에선 상세보기로 이동
     }
   };
 

--- a/src/components/common/DesignCard/DesignCard.tsx
+++ b/src/components/common/DesignCard/DesignCard.tsx
@@ -11,7 +11,7 @@ import {
   infoTitleStyle,
 } from './DesignCard.css';
 
-import { CategoryType, DesignItemType, SubCategoryType } from '@types';
+import { CategoryType, DesignItemType, SelectedModalType, SubCategoryType } from '@types';
 interface DesignCardProps extends HTMLAttributes<HTMLDivElement> {
   designItem: DesignItemType;
   numberLabel?: string;
@@ -21,7 +21,7 @@ interface DesignCardProps extends HTMLAttributes<HTMLDivElement> {
     category: CategoryType;
     subCategory: SubCategoryType;
   };
-  onSelectStore?: (storeId: number) => void;
+  onSelectStore?: ({storeId, cakeId}: SelectedModalType) => void;
 }
 
 const DesignCard = ({
@@ -49,7 +49,7 @@ const DesignCard = ({
     if (hasModal) {
       openModal(); // 둘러보기 페이지에서는 모달 띄우기
     } else if (onSelectStore) {
-      onSelectStore(storeId);
+      onSelectStore({storeId, cakeId});
     } else {
       goStorePage(storeId); // 나머지 페이지에선 상세보기로 이동
     }

--- a/src/components/common/StoreCard/StoreCard.tsx
+++ b/src/components/common/StoreCard/StoreCard.tsx
@@ -22,9 +22,10 @@ const MAX_STORE_NAME_LENGTH = 7;
 
 interface StoreCardProps extends HTMLAttributes<HTMLButtonElement> {
   storeItem: StoreType;
+  onSelectStore: (storeId: number) => void;
 }
 
-const StoreCard = ({ storeItem }: StoreCardProps) => {
+const StoreCard = ({ storeItem, onSelectStore }: StoreCardProps) => {
   const {
     storeId,
     storeName,
@@ -43,7 +44,8 @@ const StoreCard = ({ storeItem }: StoreCardProps) => {
       : storeName;
 
   const handleCardClick = () => {
-    goStorePage(storeId);
+    onSelectStore(storeId);
+    // goStorePage(storeId);
   };
 
   return (

--- a/src/components/common/StoreCard/StoreCard.tsx
+++ b/src/components/common/StoreCard/StoreCard.tsx
@@ -22,7 +22,7 @@ const MAX_STORE_NAME_LENGTH = 7;
 
 interface StoreCardProps extends HTMLAttributes<HTMLButtonElement> {
   storeItem: StoreType;
-  onSelectStore: (storeId: number) => void;
+  onSelectStore?: (storeId: number) => void;
 }
 
 const StoreCard = ({ storeItem, onSelectStore }: StoreCardProps) => {
@@ -44,8 +44,11 @@ const StoreCard = ({ storeItem, onSelectStore }: StoreCardProps) => {
       : storeName;
 
   const handleCardClick = () => {
-    onSelectStore(storeId);
-    // goStorePage(storeId);
+    if (onSelectStore) {
+      onSelectStore(storeId);
+    } else {
+      goStorePage(storeId);
+    }
   };
 
   return (

--- a/src/components/common/StoreCard/StoreCard.tsx
+++ b/src/components/common/StoreCard/StoreCard.tsx
@@ -16,13 +16,13 @@ import {
   storeNameStyle,
 } from './StoreCard.css';
 
-import { StoreType } from '@types';
+import { SelectedModalType, StoreType } from '@types';
 
 const MAX_STORE_NAME_LENGTH = 7;
 
 interface StoreCardProps extends HTMLAttributes<HTMLButtonElement> {
   storeItem: StoreType;
-  onSelectStore?: (storeId: number) => void;
+  onSelectStore?: ({storeId, cakeId}: SelectedModalType) => void;
 }
 
 const StoreCard = ({ storeItem, onSelectStore }: StoreCardProps) => {
@@ -45,7 +45,7 @@ const StoreCard = ({ storeItem, onSelectStore }: StoreCardProps) => {
 
   const handleCardClick = () => {
     if (onSelectStore) {
-      onSelectStore(storeId);
+      onSelectStore({storeId, cakeId: 0});
     } else {
       goStorePage(storeId);
     }

--- a/src/constants/apis/api.ts
+++ b/src/constants/apis/api.ts
@@ -157,6 +157,7 @@ export const END_POINT = {
 
     return url;
   },
+  FETCH_CAKE_INFO: (cakeId: number) => `/api/v1/cake/select/map/${cakeId}`,
   POST_CAKE_LIKES: (cakeId: number) => `/api/v1/cake/likes/${cakeId}`,
   POST_STORE_LIKES: (storeId: number) => `/api/v1/store/likes/${storeId}`,
   POST_LIKE: (type: 'cake' | 'store', id: number) =>

--- a/src/constants/apis/queryKey.ts
+++ b/src/constants/apis/queryKey.ts
@@ -15,6 +15,7 @@ export const queryKey = {
   LIKES_STORE_COORDINATE_LIST: 'likesStoreCoordinateList',
   STORE_STATIONS: 'storeStations',
   CAKE_RANK: 'cakeRank',
+  CAKE_INFO: 'cakeInfo',
   USER: 'user',
   STATION_DESIGN_LIST: 'stationDesignList',
   STATION_STORE_LIST: 'stationStoreList',

--- a/src/pages/view/components/KakaoMap/KakaoMap.tsx
+++ b/src/pages/view/components/KakaoMap/KakaoMap.tsx
@@ -112,6 +112,7 @@ const KakaoMap = ({ currentLocation }: KakaoMapProps) => {
           isSaveActive={isSaveActive}
           animateState={animateState}
           handleAnimateChange={handleAnimateChange}
+          onSelectStore={handleMarkerClick}
         />
       ) : (
         <Modal variant="bottom">

--- a/src/pages/view/components/KakaoMap/KakaoMap.tsx
+++ b/src/pages/view/components/KakaoMap/KakaoMap.tsx
@@ -31,6 +31,7 @@ const KakaoMap = ({ currentLocation }: KakaoMapProps) => {
   const { animateState, handleAnimateChange } = useBottomSheet();
   const { isModalOpen, openModal, closeModal } = useModal();
   const {
+    selectedCakeId,
     selectedStoreId,
     storeMarkerList,
     currentPosition,
@@ -116,7 +117,7 @@ const KakaoMap = ({ currentLocation }: KakaoMapProps) => {
         />
       ) : (
         <Modal variant="bottom">
-          <SelectedStoreModal storeId={selectedStoreId} />
+          <SelectedStoreModal storeId={selectedStoreId} cakeId={selectedCakeId} />
         </Modal>
       )}
       {isModalOpen && (

--- a/src/pages/view/components/KakaoMap/KakaoMap.tsx
+++ b/src/pages/view/components/KakaoMap/KakaoMap.tsx
@@ -80,7 +80,7 @@ const KakaoMap = ({ currentLocation }: KakaoMapProps) => {
                   src,
                   size,
                 }}
-                onClick={() => handleMarkerClick(location.storeId)}
+                onClick={() => handleMarkerClick({storeId: location.storeId, cakeId: 0})}
               />
             );
           })}

--- a/src/pages/view/components/MapBottomSheet/MapBottomSheet.tsx
+++ b/src/pages/view/components/MapBottomSheet/MapBottomSheet.tsx
@@ -17,14 +17,14 @@ import {
   spacing,
 } from './MapBottomSheet.css';
 
-import { BottomSheetState } from '@types';
+import { BottomSheetState, SelectedModalType } from '@types';
 
 interface MapBottomSheetProps {
   selectedStation: string;
   isSaveActive: boolean;
   animateState: BottomSheetState;
   handleAnimateChange: (animate: BottomSheetState) => void;
-  onSelectStore: (storeId: number) => void;
+  onSelectStore: ({storeId, cakeId}: SelectedModalType) => void;
 }
 
 const MapBottomSheet = ({

--- a/src/pages/view/components/MapBottomSheet/MapBottomSheet.tsx
+++ b/src/pages/view/components/MapBottomSheet/MapBottomSheet.tsx
@@ -24,6 +24,7 @@ interface MapBottomSheetProps {
   isSaveActive: boolean;
   animateState: BottomSheetState;
   handleAnimateChange: (animate: BottomSheetState) => void;
+  onSelectStore: (storeId: number) => void;
 }
 
 const MapBottomSheet = ({
@@ -31,6 +32,7 @@ const MapBottomSheet = ({
   isSaveActive,
   animateState,
   handleAnimateChange,
+  onSelectStore,
 }: MapBottomSheetProps) => {
   const [activeTab, setActiveTab] = useState(0);
 
@@ -89,6 +91,7 @@ const MapBottomSheet = ({
                 option={option}
                 handleOptionSelect={handleOptionSelect}
                 fetchNextPage={fetchLikedStoreNext}
+                onSelectStore={onSelectStore}
               />
             ) : (
               <CardList
@@ -97,6 +100,7 @@ const MapBottomSheet = ({
                 option={option}
                 handleOptionSelect={handleOptionSelect}
                 fetchNextPage={fetchLikedStoreDesignNext}
+                onSelectStore={onSelectStore}
               />
             )}
           </div>
@@ -110,6 +114,7 @@ const MapBottomSheet = ({
             option={option}
             handleOptionSelect={handleOptionSelect}
             fetchNextPage={fetchStationStoreNext}
+            onSelectStore={onSelectStore}
           />
         </div>
       ) : (
@@ -129,6 +134,7 @@ const MapBottomSheet = ({
                 option={option}
                 handleOptionSelect={handleOptionSelect}
                 fetchNextPage={fetchStationStoreNext}
+                onSelectStore={onSelectStore}
               />
             ) : (
               <CardList
@@ -137,6 +143,7 @@ const MapBottomSheet = ({
                 option={option}
                 handleOptionSelect={handleOptionSelect}
                 fetchNextPage={fetchStationDesignNext}
+                onSelectStore={onSelectStore}
               />
             )}
           </div>

--- a/src/pages/view/components/SelectedStoreModal/SelectedStoreModal.tsx
+++ b/src/pages/view/components/SelectedStoreModal/SelectedStoreModal.tsx
@@ -1,4 +1,5 @@
 import { useFetchStoreInfo } from '@apis/store';
+import { useFetchCakeInfo } from '@apis/view';
 
 import { IconButton, Image, Label, TextButton } from '@components';
 import { useEasyNavigate } from '@hooks';
@@ -13,32 +14,32 @@ import {
   addressStyle,
 } from './SelectedStoreModal.css';
 
-interface SelectedStoreModalProps {
-  storeId: number;
-}
-const SelectedStoreModal = ({ storeId }: SelectedStoreModalProps) => {
+import { SelectedModalType } from '@types';
+
+const SelectedStoreModal = ({ storeId, cakeId }: SelectedModalType) => {
   const { goStorePage } = useEasyNavigate();
   const { data: storeData } = useFetchStoreInfo(storeId);
-
+  const { data: cakeData } = useFetchCakeInfo(cakeId ?? 0);
+  const displayData = cakeData ?? storeData;
   return (
     <div className={modalContainer}>
       <section className={imageSection}>
-        <Image src={storeData.imageUrl} variant="rounded" />
+        <Image src={displayData.imageUrl} variant="rounded" />
       </section>
 
       <section className={infoSection}>
         <div className={textWrapper}>
           <div className={storeNameWrapper}>
-            <h1>{storeData.storeName}</h1>
+            <h1>{displayData.storeName}</h1>
             <IconButton
               buttonType={'save24'}
-              isActive={storeData.isLiked}
+              isActive={displayData.isLiked}
               itemId={storeId}
             />
           </div>
           <div className={addressWrapper}>
-            <div className={addressStyle}>{storeData.address}</div>
-            <Label text={storeData.station} />
+            <div className={addressStyle}>{displayData.address}</div>
+            <Label text={displayData.station} />
           </div>
         </div>
 

--- a/src/pages/view/hooks/useKakaoMap.tsx
+++ b/src/pages/view/hooks/useKakaoMap.tsx
@@ -10,7 +10,7 @@ import { isLoggedIn } from '@utils';
 
 import { useDebounce } from './useDebounce';
 
-import { BottomSheetState, StationType, StoreCoordinate } from '@types';
+import { BottomSheetState, SelectedModalType, StationType, StoreCoordinate } from '@types';
 
 const DEFAULT_CENTER = { lat: 37.556621, lng: 126.923877 };
 
@@ -25,6 +25,7 @@ export const useKakaoMap = (
   const { data: likesStoreCoordinateList } = useFetchLikesStoreCoordinate();
 
   const [selectedStoreId, setSelectedStoreId] = useState<number>(0);
+  const [selectedCakeId, setSelectedCakeId] = useState<number>(0);
   const [storeMarkerList, setStoreMarkerList] = useState<
     (StoreCoordinate & { clicked: boolean })[]
   >([]);
@@ -112,7 +113,7 @@ export const useKakaoMap = (
     }
   }, [isSaveActive, storeCoordinateList, likesStoreCoordinateList]);
 
-  const handleMarkerClick = (storeId: number) => {
+  const handleMarkerClick = ({storeId, cakeId}: SelectedModalType) => {
     startTransition(() => {
       setStoreMarkerList((prev) =>
         prev.map((marker) =>
@@ -122,6 +123,7 @@ export const useKakaoMap = (
         )
       );
       setSelectedStoreId(storeId);
+      setSelectedCakeId(cakeId ?? 0)
     });
   };
 
@@ -181,6 +183,7 @@ export const useKakaoMap = (
   }, [locationState]);
 
   return {
+    selectedCakeId,
     selectedStoreId,
     storeMarkerList,
     currentPosition,

--- a/src/types/apis/view/index.ts
+++ b/src/types/apis/view/index.ts
@@ -59,3 +59,17 @@ export interface StationStoreResponse {
   storeCount: number;
   stores: StationStore[];
 }
+
+export interface SelectedModalType {
+  storeId: number;
+  cakeId?: number;
+}
+
+export interface CakeInfoResponse {
+  storeId: number;
+  storeName: string;
+  address: string;
+  station: string;
+  isLiked: boolean;
+  imageUrl: string;
+}


### PR DESCRIPTION
<!-- PR의 제목은 "[Feat/#1] 로그인 기능 추가" 와 같이 작성해주세요! -->

### 📌 관련 이슈번호

- Closes #229 
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->

---

### 체크리스트

- [x] 🎋 base 브랜치를 develop 브랜치로 설정했나요?
- [x] 🖌️ PR 제목은 형식에 맞게 잘 작성했나요? <!-- e.g. [Feat/#1] 로그인 기능 추가 -->
- [x] 🏗️ 빌드는 성공했나요? (yarn build)
- [x] 🧹 불필요한 코드는 제거했나요? e.g. console.log
- [x] 🙇‍♂️ 리뷰어를 지정했나요? 
- [x] 🏷️ 라벨은 등록했나요?

---

### ✅ Key Changes

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 지도뷰 모달 flow 수정
   - 기존에 지도뷰에서는 StoreCard 컴포넌트를 클릭시 SelectedStoreModal 컴포넌트가 뜬 후 해당 스토어의 상세페이지로 이동했지만, DesignCard는 클릭 즉시 해당 케이크 디자인을 가진 스토어의 상세페이지로 이동했습니다. 이를 StoreCard 컴포넌트와 동일한 flow로 수정했습니다.
   - 수정을 위해 해당 모달을 띄우는 로직인 handleMarkerClick 함수를 StoreCard, DesignCard 컴포넌트까지 전달해줬습니다. 이후 api 연결 설명에서 이어서 설명하겠습니다.

2. 지도뷰 선택 디자인 조회 api 연결
   - 위 flow 수정과 이어서 DesignCard 컴포넌트를 클릭시 해당 디자인의 cakeId를 가지고 api를 요청하고 이 응답값을 SelectedStoreModal 컴포넌트에 전달해야 합니다. 기존에는 storeId만을 매개변수로 받았지만 수정을 통해 cakeId값을 옵셔널로 받을 수 있도록 수정하고, StoreCard 컴포넌트 클릭시에는 cakeId값을 0으로 전달했고, 이때 에러를 방지하기 위해 응답 데이터가 없을 경우 null로 처리해줬습니다.


---

### 📢 To Reviewers

-

---

### 📸 스크린샷 or 실행영상
<!-- 이해하기 쉽도록 스크린샷을 첨부해주세요. -->
